### PR TITLE
Reworked configpanel

### DIFF
--- a/src/BDTranslations.Config
+++ b/src/BDTranslations.Config
@@ -173,8 +173,8 @@
     <EN>Failed!</EN>
 </T0043>
 <T0044>
-    <FR>Durée du pop-up de choix (en s)</FR>
-    <EN>Choice pop-up duration (s)</EN>
+    <FR>Fermeture automatique du pop-up de choix après (en s)</FR>
+    <EN>Automatically close choice pop-up after (s)</EN>
 </T0044>
 <T0045>
     <FR>Ignorer et passer à la suite</FR>
@@ -302,7 +302,7 @@
 </T0075>
 <T0076>
     <FR>Lettreur(s) de l'album</FR>
-    <EN>Comic book's letterer</EN>
+    <EN>Comic book's letterer(s)</EN>
 </T0076>
 <T0077>
     <FR>Format de la série</FR>
@@ -589,8 +589,8 @@
     <EN>Automatic choice of comic books' edition</EN>
 </T0147>
 <T0148>
-    <FR>Longueur des numéros d'album (complétée de 0)</FR>
-    <EN>Length of the comic book's numbers (0-padded)</EN>
+    <FR>Longueur des numéros d'album (complétée à gauche par 0)</FR>
+    <EN>Length of the comic book's numbers (left-padded with 0)</EN>
 </T0148>
 <T0149>
     <FR>Résumé de la série sur le 1er tome seulement</FR>

--- a/src/BDTranslations.Config
+++ b/src/BDTranslations.Config
@@ -1,607 +1,607 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 <T0001>
-	<FR>Aucun Album selectionée...</FR>
-	<EN>No Comic selected...</EN>
+    <FR>Aucun album sélectionné...</FR>
+    <EN>No comic book selected...</EN>
 </T0001>
 <T0002>
-	<FR>Erreur !</FR>
-	<EN>Error !</EN>
+    <FR>Erreur !</FR>
+    <EN>Error !</EN>
 </T0002>
 <T0003>
-	<FR>Le fichier BD2_Rename_Log.txt est trop grand. Confirmez le remplacement</FR>
-	<EN>The file BD2_Rename_Log.txt is too big. Confirm cleaning </EN>
+    <FR>Le fichier BD2_Rename_Log.txt est trop grand. Confirmez le remplacement</FR>
+    <EN>The file BD2_Rename_Log.txt is too big. Confirm cleaning </EN>
 </T0003>
 <T0004>
-	<FR>Fichier de Log</FR>
-	<EN>Rename Log File</EN>
+    <FR>Fichier de Log</FR>
+    <EN>Rename Log File</EN>
 </T0004>
 <T0005>
-	<FR>Le fichier BD2_Debug_Log.txt est trop grand. Confirmez le remplacement</FR>
-	<EN>The file BD2_Debug_Log.txt is too big. Confirm cleaning </EN>
+    <FR>Le fichier BD2_Debug_Log.txt est trop grand. Confirmez le remplacement</FR>
+    <EN>The file BD2_Debug_Log.txt is too big. Confirm cleaning </EN>
 </T0005>
 <T0006>
-		<FR>Fichier de Log</FR>
-	<EN>Debug Log File</EN>
+    <FR>Fichier de Log</FR>
+    <EN>Debug Log File</EN>
 </T0006>
 <T0007>
-	<FR> ** Démarrage du traitement **</FR>
-	<EN> ** Scraping started **  </EN>
+    <FR> ** Démarrage du traitement **</FR>
+    <EN> ** Scraping started **  </EN>
 </T0007>
 <T0008>
-	<FR> Album(s)</FR>
-		<EN> Comic(s)</EN>
+    <FR> Album(s)</FR>
+    <EN> Comic(s)</EN>
 </T0008>
 <T0009>
-	<FR>Nom Série = </FR>
-	<EN>Series' Name = </EN>
+    <FR>Nom de la série = </FR>
+    <EN>Series' name = </EN>
 </T0009>
 <T0010>
-	<FR>Recherche sur le Web avec Nom de Série:</FR>
-	<EN>Searching the Web with the Series' Name:</EN>
+    <FR>Recherche sur le web avec le nom de série:</FR>
+    <EN>Searching the web with the series' name:</EN>
 </T0010>
 <T0011>
-	<FR>Recherche sur le Web avec No. d'Album [</FR>
-	<EN>Searching the Web with the Comic's No. [</EN>
+    <FR>Recherche sur le web avec numéro d'album [</FR>
+    <EN>Searching the web with the comic book's number [</EN>
 </T0011>
 <T0012>
-	<FR>Recherche sur le Web comme Album [</FR>
-	<EN>Searching the Web like Comic [</EN>
+    <FR>Recherche sur le web comme album [</FR>
+    <EN>Searching the web like comic book [</EN>
 </T0012>
 <T0013>
-	<FR> ** Renommé **</FR>
-	<EN> ** Renamed **</EN>
+    <FR> ** Traité **</FR>
+    <EN> ** Processed **</EN>
 </T0013>
 <T0014>
-	<FR> ** Ignoré **</FR>
-	<EN> ** Skipped **</EN>
+    <FR> ** Ignoré **</FR>
+    <EN> ** Skipped **</EN>
 </T0014>
 <T0015>
-	<FR>Erreur générale, pas de BD sélectionnée !</FR>
-	<EN>General Error! No Comic selected!</EN>
+    <FR>Erreur générale, pas d'album sélectionné !</FR>
+    <EN>General Error! No comic book selected!</EN>
 </T0015>
 <T0016>
-	<FR>Fini</FR>
-	<EN>Completed</EN>
+    <FR>Fini</FR>
+    <EN>Complete</EN>
 </T0016>
 <T0017>
-	<FR>Renommés: </FR>
-	<EN>Renamed: </EN>
+    <FR>Traités: </FR>
+    <EN>Processed: </EN>
 </T0017>
 <T0018>
-	<FR>Ignorés: </FR>
-	<EN>Skipped: </EN>
+    <FR>Ignorés: </FR>
+    <EN>Skipped: </EN>
 </T0018>
 <T0019>
-	<FR>Erreurs présentes: ouvrir DEBUG Log ?</FR>
-	<EN>Errors in Scraping: open DEBUG Log ?</EN>
+    <FR>Erreurs présentes: ouvrir le log de debug ?</FR>
+    <EN>Errors in scraping: open debug log ?</EN>
 </T0019>
 <T0020>
-	<FR>Erreur de numérotation !</FR>
-	<EN>Scraping error !</EN>
+    <FR>Erreur de traitement !</FR>
+    <EN>Scraping error !</EN>
 </T0020>
 <T0021>
-	<FR>Ouvrir Rename Log ?</FR>
-	<EN>Open Rename Log ?</EN>
+    <FR>Ouvrir le rapport ?</FR>
+    <EN>Open report ?</EN>
 </T0021>
 <T0022>
-	<FR>Traitement fini !</FR>
-	<EN>Scraping Completed !</EN>
+    <FR>Traitement fini !</FR>
+    <EN>Scraping completed !</EN>
 </T0022>
 <T0023>
-	<FR>URL Série: </FR>
-	<EN>Series' URL: </EN>
+    <FR>Lien internet de la série: </FR>
+    <EN>Web link of the series: </EN>
 </T0023>
 <T0024>
-	<FR>** Série non trouvée [</FR>
-	<EN>** Series unknown [</EN>
+    <FR>** Série non trouvée [</FR>
+    <EN>** Series unknown [</EN>
 </T0024>
 <T0025>
-	<FR> non trouvé</FR>
-	<EN> not found</EN>
+    <FR> non trouvé</FR>
+    <EN> not found</EN>
 </T0025>
 <T0026>
-	<FR>** URL de l'Album dans la Série: </FR>
-	<EN>** Comic's URL in the Series: </EN>
+    <FR>** Lien internet de l'album: </FR>
+    <EN>** Comic book's web link: </EN>
 </T0026>
 <T0027>
-	<FR>** Album non trouvé comme: [</FR>
-	<EN>** Comic is unknown as: [</EN>
+    <FR>** Album non trouvé comme: [</FR>
+    <EN>** Comic book is unknown as: [</EN>
 </T0027>
 <T0028>
-	<FR>** Album non trouvé</FR>
-	<EN>** Comic unknown</EN>
+    <FR>** Album non trouvé</FR>
+    <EN>** Comic book unknown</EN>
 </T0028>
 <T0029>
-	<FR>Titre: </FR>
-	<EN>Title:</EN>
+    <FR>Titre de l'album: </FR>
+    <EN>Comic book's title: </EN>
 </T0029>
 <T0030>
-	<FR>Scénariste(s): </FR>
-	<EN>Author(s): </EN>
+    <FR>Scénariste(s) de l'album: </FR>
+    <EN>Comic book's author(s): </EN>
 </T0030>
 <T0031>
-	<FR>Dessinateur(s): </FR>
-	<EN>Penciller(s): </EN>
+    <FR>Dessinateur(s) de l'album: </FR>
+    <EN>Comic book's penciller(s): </EN>
 </T0031>
 <T0032>
-	<FR>(vidé)</FR>
-	<EN>(blanked)</EN>
+    <FR>(ignoré)</FR>
+    <EN>(blanked)</EN>
 </T0032>
 <T0033>
-	<FR>Coloriste(s): </FR>
-	<EN>Colorist(s): </EN>
+    <FR>Coloriste(s) de l'album: </FR>
+    <EN>Comic book's colorist(s): </EN>
 </T0033>
 <T0034>
-	<FR>Dépot légal: </FR>
-	<EN>Legal Deposit: </EN>
+    <FR>Date de publication de l'album: </FR>
+    <EN>Comic book's publication date: </EN>
 </T0034>
 <T0035>
-	<FR>Editeur: </FR>
-	<EN>Editor: </EN>
+    <FR>Éditeur de la série: </FR>
+    <EN>Series' publisher: </EN>
 </T0035>
 <T0036>
-	<FR>Langue: </FR>
-	<EN>Language: </EN>
+    <FR>Langue de la série: </FR>
+    <EN>Series' language: </EN>
 </T0036>
 <T0037>
-	<FR>Chaîne fin nom de série</FR>
-	<EN>Serie name ending string</EN>
+    <FR>Chaîne de fin nom de série à supprimer</FR>
+    <EN>Series' name ending string to suppress</EN>
 </T0037>
 <T0038>
-	<FR>Lettrage: </FR>
-	<EN>Lettering: </EN>
+    <FR>Lettreur(s) de l'album: </FR>
+    <EN>Comic book's letterer(s): </EN>
 </T0038>
 <T0039>
-	<FR>Note Album: </FR>
-	<EN>Comic's Rating: </EN>
+    <FR>Évaluation de l'album: </FR>
+    <EN>Comic book's rating: </EN>
 </T0039>
 <T0040>
-	<FR>Achevé Impr.: </FR>
-	<EN>Printed on: </EN>
+    <FR>Achevé d'imprimer: </FR>
+    <EN>Printed on: </EN>
 </T0040>
 <T0041>
-	<FR>Collection: </FR>
-	<EN>Imprint: </EN>
+    <FR>Marque d'éditeur de l'album (Collection): </FR>
+    <EN>Comic book's imprint: </EN>
 </T0041>
 <T0042>
-	<FR>Taille: </FR>
-	<EN>Format: </EN>
+    <FR>Format de l'album: </FR>
+    <EN>Comic book's format: </EN>
 </T0042>
 <T0043>
-	<FR>Echec!</FR>
-	<EN>Failed!</EN>
+    <FR>Échec!</FR>
+    <EN>Failed!</EN>
 </T0043>
 <T0044>
-	<FR>Durée pop-up choix (en s)</FR>
-	<EN>Choice pop-up duration (s)</EN>
+    <FR>Durée du pop-up de choix (en s)</FR>
+    <EN>Choice pop-up duration (s)</EN>
 </T0044>
 <T0045>
-	<FR>** Informations de la série utilisées !</FR>
-	<EN>** The Series' information has been used !</EN>
+    <FR>Ignorer et passer à la suite</FR>
+    <EN>Ignore and skip to the next item</EN>
 </T0045>
 <T0046>
-	<FR>[No. vide]</FR>
-	<EN>[Empty #]</EN>
+    <FR>Demander à l'utilisateur de choisir</FR>
+    <EN>User choose between choices</EN>
 </T0046>
 <T0047>
-	<FR> Informations de la série utilisées !</FR>
-	<EN> The Series' information has been used !</EN>
+    <FR>Logging</FR>
+    <EN>Logging</EN>
 </T0047>
 <T0048>
-	<FR>Le No. [</FR>
-	<EN>Number [</EN>
+    <FR>Utiliser des liens internet raccourcis pour les albums</FR>
+    <EN>Use shortened web links for comic books</EN>
 </T0048>
 <T0049>
-	<FR> n'existe pas pour l'Album ! Vérifiez SVP.</FR>
-	<EN> does not exist for the Comic. Please verify.</EN>
+    <FR> n'existe pas pour l'album ! Vérifiez SVP.</FR>
+    <EN> does not exist for the comic book. Please verify.</EN>
 </T0049>
 <T0050>
-	<FR>N'existe pas pour l'Album ! Vérifiez SVP.</FR>
-	<EN>It doesn't exist for the Comic. Please verify.</EN>
+    <FR>N'existe pas pour l'album ! Vérifiez SVP.</FR>
+    <EN>It doesn't exist for the comic book. Please verify.</EN>
 </T0050>
 <T0051>
-	<FR>Genre: </FR>
-	<EN>Genre: </EN>
+    <FR>Genre: </FR>
+    <EN>Genre: </EN>
 </T0051>
 <T0052>
-	<FR>Résumé Série: trouvé !</FR>
-	<EN>Series' Synopsys: found !</EN>
+    <FR>Résumé de la série trouvé !</FR>
+    <EN>Series' synopsis found !</EN>
 </T0052>
 <T0053>
-	<FR>** Résumé Série non trouvé !</FR>
-	<EN>** Series' Synopsys NOT found !</EN>
+    <FR>** Résumé de la série non trouvé !</FR>
+    <EN>** Series' synopsis not found !</EN>
 </T0053>
 <T0054>
-	<FR>Finie</FR>
-	<EN>Terminated</EN>
+    <FR>Finie</FR>
+    <EN>Terminated</EN>
 </T0054>
 <T0055>
-	<FR>En cours</FR>
-	<EN>Running</EN>
+    <FR>En cours</FR>
+    <EN>Running</EN>
 </T0055>
 <T0056>
-	<FR>Inconnue</FR>
-	<EN>Unknown</EN>
+    <FR>Inconnue</FR>
+    <EN>Unknown</EN>
 </T0056>
 <T0057>
-	<FR>Série </FR>
-	<EN>Series </EN>
+    <FR>État de parution de la série: </FR>
+    <EN>Publication state of the series:</EN>
 </T0057>
 <T0058>
-	<FR>Note Série: </FR>
-	<EN>Series' Rating: </EN>
+    <FR>Évaluation de la série: </FR>
+    <EN>Series' rating: </EN>
 </T0058>
 <T0059>
-	<FR>No. Total Album: </FR>
-	<EN>Total N. of Comics: </EN>
+    <FR>Nombre total d'albums: </FR>
+    <EN>Total number of comics: </EN>
 </T0059>
 <T0060>
-	<FR>Echec d'accés au serveur</FR>
-	<EN>Failed access to the server</EN>
+    <FR>Échec d'accés au serveur</FR>
+    <EN>Failed access to the server</EN>
 </T0060>
 <T0061>
-	<FR>Raison: </FR>
-	<EN>Reason: </EN>
+    <FR>Raison: </FR>
+    <EN>Reason: </EN>
 </T0061>
 <T0062>
-	<FR>Traitement fichiers</FR>
-	<EN>Scraping files</EN>
+    <FR>Traitement des fichiers</FR>
+    <EN>Scraping files</EN>
 </T0062>
 <T0063>
-	<FR>Traitement fichiers </FR>
-	<EN>Scraping files </EN>
+    <FR>Traitement des fichiers </FR>
+    <EN>Scraping files </EN>
 </T0063>
 <T0064>
-	<FR>Config Utilisée: </FR>
-	<EN>Configuration Used: </EN>
+    <FR>Configuration utilisée: </FR>
+    <EN>Configuration used: </EN>
 </T0064>
 <T0065>
-	<FR>Config Sauvée: </FR>
-	<EN>Saved Configuration: </EN>
+    <FR>Configuration sauvegardée: </FR>
+    <EN>Saved configuration: </EN>
 </T0065>
 <T0066>
-	<FR>Afficher le Rename Log aprés le traitement</FR>
-	<EN>Show the Rename Log after scraping</EN>
+    <FR>Afficher le rapport après le traitement</FR>
+    <EN>Show report after scraping</EN>
 </T0066>
 <T0067>
-	<FR>Afficher le Debug Log aprés une erreur</FR>
-	<EN>Show the Debug Log after an error</EN>
+    <FR>Afficher le log de debug après une erreur</FR>
+    <EN>Show the debug log after an error</EN>
 </T0067>
 <T0068>
-	<FR>Activer le Debug interne</FR>
-	<EN>Activate the internal Debug</EN>
+    <FR>Activer le log de debug</FR>
+    <EN>Activate the debug log</EN>
 </T0068>
 <T0069>
-	<FR>Taille MAX Dbg_Log</FR>
-	<EN>MAX size Dbg_Log</EN>
+    <FR>Taille maximale du fichier de log de debug (en MO)</FR>
+    <EN>Maximum size of debug log file (MB)</EN>
 </T0069>
 <T0070>
-	<FR>Taille MAX Ren_Log</FR>
-	<EN>MAX size Ren_Log</EN>
+    <FR>Taille maximale du fichier de rapport (en MO)</FR>
+    <EN>Maximum size of the report file (MB)</EN>
 </T0070>
 <T0071>
-	<FR>Série</FR>
-	<EN>Series</EN>
+    <FR>Nom de la série</FR>
+    <EN>Series' name</EN>
 </T0071>
 <T0072>
-	<FR>Titre</FR>
-	<EN>Title</EN>
+    <FR>Titre de l'album</FR>
+    <EN>Comic book's title</EN>
 </T0072>
 <T0073>
-	<FR>Scénario</FR>
-	<EN>Author</EN>
+    <FR>Scénariste(s) de l'album</FR>
+    <EN>Comic book's author(s)</EN>
 </T0073>
 <T0074>
-	<FR>Dessin</FR>
-	<EN>Penciller</EN>
+    <FR>Dessinateur(s) de l'album</FR>
+    <EN>Comic book's penciller(s)</EN>
 </T0074>
 <T0075>
-	<FR>Couleurs</FR>
-	<EN>Colorist</EN>
+    <FR>Coloriste(s) de l'album</FR>
+    <EN>Comic book's colorist(s)</EN>
 </T0075>
 <T0076>
-	<FR>Lettrage</FR>
-	<EN>Letterer</EN>
+    <FR>Lettreur(s) de l'album</FR>
+    <EN>Comic book's letterer</EN>
 </T0076>
 <T0077>
-	<FR>Taille</FR>
-	<EN>Format</EN>
+    <FR>Format de la série</FR>
+    <EN>Series' format</EN>
 </T0077>
 <T0078>
-	<FR>Editeur</FR>
-	<EN>Publisher</EN>
+    <FR>Éditeur de la série</FR>
+    <EN>Series' publisher</EN>
 </T0078>
 <T0079>
-	<FR>Langue</FR>
-	<EN>Language</EN>
+    <FR>Langue de la série</FR>
+    <EN>Series' language</EN>
 </T0079>
 <T0080>
-	<FR>ISBN</FR>
-	<EN>ISBN</EN>
+    <FR>Numéro ISBN de l'album</FR>
+    <EN>Comic book's ISBN number</EN>
 </T0080>
 <T0081>
-	<FR>Note</FR>
-	<EN>Rating</EN>
+    <FR>Évaluation de l'album</FR>
+    <EN>Comic book's rating</EN>
 </T0081>
 <T0082>
-	<FR>Dep.Légal</FR>
-	<EN>Leg.Deposit</EN>
+    <FR>Date de publication de l'album</FR>
+    <EN>Comic book's publication date</EN>
 </T0082>
 <T0083>
-	<FR>Collection</FR>
-	<EN>Imprint</EN>
+    <FR>Marque d'éditeur de l'album (Collection)</FR>
+    <EN>Comic book's imprint</EN>
 </T0083>
 <T0084>
-	<FR>Résumé</FR>
-	<EN>Synopsys</EN>
+    <FR>Résumé de la série et de l'album</FR>
+    <EN>Series and comic book's synopsis</EN>
 </T0084>
 <T0085>
-	<FR>... Sur</FR>
-	<EN>... of</EN>
+    <FR>Nombre total d'albums dans la série</FR>
+    <EN>Total number of comic books in the series</EN>
 </T0085>
 <T0086>
-	<FR>Annotat.</FR>
-	<EN>Notes</EN>
+    <FR>Annotations de l'album</FR>
+    <EN>Comic book's notes</EN>
 </T0086>
 <T0087>
-	<FR>S. Complète</FR>
-	<EN>S. Completed</EN>
+    <FR>Série complète</FR>
+    <EN>Series complete</EN>
 </T0087>
 <T0088>
-	<FR>Web</FR>
-	<EN>Web</EN>
+    <FR>Lien internet de l'album</FR>
+    <EN>Comic book's web link</EN>
 </T0088>
 <T0089>
-	<FR>Genre</FR>
-	<EN>Genre</EN>
+    <FR>Genre de la série</FR>
+    <EN>Series' genre</EN>
 </T0089>
 <T0090>
-	<FR>Img. Couvert.</FR>
-	<EN>Cover Img.</EN>
+    <FR>Image de couverture de l'album</FR>
+    <EN>Comic book's cover image</EN>
 </T0090>
 <T0091>
-	<FR>Etiq.</FR>
-	<EN>Tags</EN>
+    <FR>Étiquettes des albums</FR>
+    <EN>Comic books' tags</EN>
 </T0091>
 <T0092>
-	<FR>OK</FR>
-	<EN>OK</EN>
+    <FR>OK</FR>
+    <EN>OK</EN>
 </T0092>
 <T0093>
-	<FR>Annuler</FR>
-	<EN>Cancel</EN>
+    <FR>Annuler</FR>
+    <EN>Cancel</EN>
 </T0093>
 <T0094>
-	<FR>Réinit.</FR>
-	<EN>Reset</EN>
+    <FR>Tout désélectionner</FR>
+    <EN>Uncheck all</EN>
 </T0094>
 <T0095>
-	<FR>Install.</FR>
-	<EN>Setup</EN>
+    <FR>Préférences</FR>
+    <EN>Settings</EN>
 </T0095>
 <T0096>
-	<FR>Données</FR>
-	<EN>Data</EN>
+    <FR>Données</FR>
+    <EN>Data</EN>
 </T0096>
 <T0097>
-	<FR>Erreur HTTP</FR>
-	<EN>HTTP error</EN>
+    <FR>Erreur HTTP</FR>
+    <EN>HTTP error</EN>
 </T0097>
 <T0098>
-	<FR>Erreur: </FR>
-	<EN>Error: </EN>
+    <FR>Erreur: </FR>
+    <EN>Error: </EN>
 </T0098>
 <T0099>
-	<FR>Annuler</FR>
-	<EN>Cancel</EN>
+    <FR>Annuler</FR>
+    <EN>Cancel</EN>
 </T0099>
 <T0100>
-	<FR>Résumé Album trouvé !</FR>
-	<EN>Comic's Synopsys found !</EN>
+    <FR>Résumé de l'album trouvé !</FR>
+    <EN>Comic book's synopsis found !</EN>
 </T0100>
 <T0101>
-	<FR>** Résumé Album non trouvé !</FR>
-	<EN>** Comic's Synopsys NOT found !</EN>
+    <FR>** Résumé de l'album non trouvé !</FR>
+    <EN>** Comic book's synopsis not found !</EN>
 </T0101>
 <T0102>
-	<FR>Coller le lien BD du www.bedetheque.com</FR>
-	<EN>Paste Album Link from www.bedetheque.com</EN>
+    <FR>Coller le lien BD du www.bedetheque.com</FR>
+    <EN>Paste Album Link from www.bedetheque.com</EN>
 </T0102>
 <T0103>
-	<FR>Scrape directement un lien</FR>
-	<EN>Scrape directly a link</EN>
+    <FR>Scrape directement un lien</FR>
+    <EN>Scrape directly a link</EN>
 </T0103>
 <T0104>
-	<FR>Recherche sur le Web avec Lien direct</FR>
-	<EN>Searching the Web with direct link</EN>
+    <FR>Recherche sur le web avec un lien direct</FR>
+    <EN>Searching the web with direct link</EN>
 </T0104>
 <T0105>
-	<FR>Couverture trouvée: </FR>
-	<EN>Cover found: </EN>
+    <FR>Couverture trouvée: </FR>
+    <EN>Cover found: </EN>
 </T0105>
 <T0106>
-	<FR>Erreur lien !</FR>
-	<EN>Link error !</EN>
+    <FR>Erreur lien !</FR>
+    <EN>Link error !</EN>
 </T0106>
 <T0107>
-	<FR>Album trouvé !</FR>
-	<EN>Comic found !</EN>
+    <FR>Album trouvé !</FR>
+    <EN>Comic book found !</EN>
 </T0107>
 <T0108>
-	<FR>Selectionnée: </FR>
-	<EN>Selected: </EN>
+    <FR>Sélectionnés: </FR>
+    <EN>Selected: </EN>
 </T0108>
 <T0109>
-	<FR>Articles: </FR>
-	<EN>Articles: </EN>
+    <FR>Articles principaux</FR>
+    <EN>Leading articles</EN>
 </T0109>
 <T0110>
-	<FR>"Num. de" réel ?</FR>
-	<EN>Real "Count of" ?</EN>
+    <FR>Nombre total d'albums basé sur la numérotation des tomes</FR>
+    <EN>Total number of comic books from volume numbering</EN>
 </T0110>
 <T0111>
-	<FR>Série selectionnée: </FR>
-	<EN>Selected Series: </EN>
+    <FR>Série sélectionnée: </FR>
+    <EN>Selected series: </EN>
 </T0111>
 <T0112>
-	<FR>Série renommée: </FR>
-	<EN>Series renamed: </EN>
+    <FR>Langue du plugin</FR>
+    <EN>Plugin language</EN>
 </T0112>
 <T0113>
-	<FR>Recherche générique dans </FR>
-	<EN>Generic search in </EN>
+    <FR>Recherche générique dans </FR>
+    <EN>Generic search in </EN>
 </T0113>
 <T0114>
-	<FR>La recherche effectuée renvoie trop de résultats pour </FR>
-	<EN>The search retrieves too many hits for </EN>
+    <FR>La recherche effectuée renvoie trop de résultats pour </FR>
+    <EN>The search retrieves too many hits for </EN>
 </T0114>
 <T0115>
-	<FR>Num.: </FR>
-	<EN>Number: </EN>
+    <FR>Numéro: </FR>
+    <EN>Number: </EN>
 </T0115>
 <T0116>
-	<FR>Alt. Num.: </FR>
-	<EN>Alt. Number: </EN>
+    <FR>Numéro alternatif: </FR>
+    <EN>Alternate Number: </EN>
 </T0116>
 <T0117>
-	<FR> </FR>
-	<EN> </EN>
+    <FR>Tout sélectionner</FR>
+    <EN>Check all</EN>
 </T0117>
 <T0118>
-	<FR>Info édition: </FR>
-	<EN>Edition Info: </EN>
+    <FR>Info édition: </FR>
+    <EN>Edition info: </EN>
 </T0118>
 <T0119>
-	<FR> trouvé !</FR>
-	<EN> found !</EN>
+    <FR> trouvé !</FR>
+    <EN> found !</EN>
 </T0119>
 <T0120>
-	<FR>Couverture: </FR>
-	<EN>Cover Artist: </EN>
+    <FR>Artiste(s) de couverture de l'album: </FR>
+    <EN>Comic book's cover artist(s): </EN>
 </T0120>
 <T0121>
-	<FR>Couverture</FR>
-	<EN>Cover Artist</EN>
+    <FR>Artiste(s) de couverture de l'album</FR>
+    <EN>Comic book's cover artist(s)</EN>
 </T0121>
 <T0122>
-	<FR>N. de Planches: </FR>
-	<EN>N. of Pages: </EN>
+    <FR>Nombre de planches: </FR>
+    <EN>Number of pages: </EN>
 </T0122>
 <T0123>
-	<FR>** URL de l'Album: </FR>
-	<EN>** Comic's URL: </EN>
+    <FR>** Lien internet de l'album: </FR>
+    <EN>** Comic book's web link: </EN>
 </T0123>
 <T0124>
-	<FR># Temps nécessaire pour le Scrape Total: </FR>
-	<EN>Time taken to Scrape all: </EN>
+    <FR># Temps nécessaire pour le traitement total: </FR>
+    <EN>Time taken to scrape all: </EN>
 </T0124>
 <T0125>
-	<FR># Temps nécessaire: </FR>
-	<EN>Time needed: </EN>
+    <FR># Temps nécessaire: </FR>
+    <EN>Time needed: </EN>
 </T0125>
 <T0126>
-	<FR>Seul. si terminée</FR>
-	<EN>Only if finished</EN>
+    <FR>Nombre total d'albums seulement si la série est terminée</FR>
+    <EN>Total number of comic books only if series is complete</EN>
 </T0126>
 <T0127>
-	<FR>Notation Pascal (Séries, Titre)</FR>
-	<EN>Pascal Case (Series, Title)</EN>
+    <FR>Convention Pascal Case pour les noms de séries et d'albums</FR>
+    <EN>Pascal Case convention for series and books' names</EN>
 </T0127>
 <T0128>
-	<FR>Max Scrape</FR>
-	<EN>Max Scrape</EN>
+    <FR>Nombre maximal d'albums à traiter</FR>
+    <EN>Maximal book number to scrape</EN>
 </T0128>
 <T0129>
-	<FR>Intervalle Scrape</FR>
-	<EN>Scrape Interval</EN>
+    <FR>Temps de pause entre 2 albums (en s)</FR>
+    <EN>Waiting time between 2 books (s)</EN>
 </T0129>
 <T0130>
-	<FR>En attendant...</FR>
-	<EN>Waiting...</EN>
+    <FR>En cours...</FR>
+    <EN>Waiting...</EN>
 </T0130>
 <T0131>
-	<FR>Periodicité: </FR>
-	<EN>Frequency: </EN>
+    <FR>Périodicité: </FR>
+    <EN>Frequency: </EN>
 </T0131>
 <T0132>
-	<FR>Choisissez une Série pour </FR>
-	<EN>Pick a Series for </EN>
+    <FR>Choisissez une série pour </FR>
+    <EN>Pick a series for </EN>
 </T0132>
 <T0133>
-	<FR>Choisissez une Revue pour </FR>
-	<EN>Pick a Mag for </EN>
+    <FR>Choisissez une revue pour </FR>
+    <EN>Pick a Mag for </EN>
 </T0133>
 <T0134>
-	<FR>Coller le lien Revue du www.bedetheque.com</FR>
-	<EN>Paste Magazine Link from www.bedetheque.com</EN>
+    <FR>Coller le lien de la revue depuis www.bedetheque.com</FR>
+    <EN>Paste magazine link from www.bedetheque.com</EN>
 </T0134>
 <T0135>
-	<FR>N. Revue</FR>
-	<EN>Magazine #</EN>
+    <FR>Numéro de la revue</FR>
+    <EN>Magazine number</EN>
 </T0135>
 <T0136>
-	<FR>Val. Proposée</FR>
-	<EN>Proposed Val.</EN>
+    <FR>Utiliser les valeurs proposées provenant du nom de fichier</FR>
+    <EN>Use proposed values from filename</EN>
 </T0136>
 <T0137>
-	<FR>Rescrape de Web</FR>
-	<EN>Rescrape from Web</EN>
+    <FR>Exécuter un rescrape à partir des liens internet des albums</FR>
+    <EN>Process a rescrape from comic books' web links</EN>
 </T0137>
 <T0138>
-	<FR>Rescraping...</FR>
-	<EN>Rescraping...</EN>
+    <FR>Rescraping...</FR>
+    <EN>Rescraping...</EN>
 </T0138>
 <T0139>
-	<FR>Vous exécutez un Rescrape: Les Albums sans lien Web seront ignoré. Confirmer ?</FR>
-	<EN>You are Rescraping: All Albums without a Web link will be ignored. Confirm ?</EN>
+    <FR>Vous exécutez un rescrape: les albums sans lien web seront ignorés. Confirmer ?</FR>
+    <EN>You are rescraping: all albums without a web link will be ignored. Confirm ?</EN>
 </T0139>
 <T0140>
-	<FR>Interruption de %% secondes...</FR>
-	<EN>Pausing for timeout of %% seconds...</EN>
+    <FR>Interruption de %% secondes...</FR>
+    <EN>Pausing for timeout of %% seconds...</EN>
 </T0140>
 <T0141>
-	<FR>Pause scrape</FR>
-	<EN>Pause scraping</EN>
+    <FR>Décision lorsqu'une ambiguité de choix de série ou d'album se présente</FR>
+    <EN>Decision when an ambiguity in the choice of series or book arises</EN>
 </T0141>
 <T0142>
-	<FR>Album ignoré, non univoque</FR>
-	<EN>Album ignored, not univoque</EN>
+    <FR>Album ignoré, non univoque</FR>
+    <EN>Album ignored, not univoque</EN>
 </T0142>
 <T0143>
-	<FR>Erreur ! Trop liens selectionèe!</FR>
-	<EN>Error ! Too many items selected!</EN>
+    <FR>Erreur ! Trop liens selectionèe!</FR>
+    <EN>Error ! Too many items selected!</EN>
 </T0143>
 <T0144>
-	<FR>Articles Formatés (Séries)</FR>
-	<EN>Formatted Articles (Series)</EN>
+    <FR>Déplacer les articles principaux du nom des séries à la fin</FR>
+    <EN>Moving leading articles of series' name to the end</EN>
 </T0144>
 <T0145>
-	<FR>Choisissez une Édition pour </FR>
-	<EN>Pick an Edition for </EN>
+    <FR>Choisissez une édition pour </FR>
+    <EN>Pick an edition for </EN>
 </T0145>
 <T0146>
-	<FR>Choisissez un Album pour </FR>
-	<EN>Pick an Album for </EN>
+    <FR>Choisissez un album pour </FR>
+    <EN>Pick an comic book for </EN>
 </T0146>
 <T0147>
-	<FR>Éditions Automatique</FR>
-	<EN>Automatic Editions</EN>
+    <FR>Choix automatique de l'édition des albums</FR>
+    <EN>Automatic choice of comic books' edition</EN>
 </T0147>
 <T0148>
-	<FR>Compl. no. album avec 0</FR>
-	<EN>Pad album number with 0</EN>
+    <FR>Longueur des numéros d'album (complétée de 0)</FR>
+    <EN>Length of the comic book's numbers (0-padded)</EN>
 </T0148>
 <T0149>
-	<FR>Résumé série sur 1er Tome seul.</FR>
-	<EN>Series summary on 1st book only</EN>
+    <FR>Résumé de la série sur le 1er tome seulement</FR>
+    <EN>Series' synopsis on 1st comic book only</EN>
 </T0149>
 <T0150>
-	<FR>Remplace le champ Taille avec One Shot</FR>
-	<EN>Replace Format with One Shot</EN>
+    <FR>Remplacer le format de l'album par "One Shot" si applicable</FR>
+    <EN>Replace comic book's format by "One Shot" if applicable</EN>
 </T0150>
 <T0151>
-    <FR>Touj. choisir les Séries manuel.</FR>
-    <EN>Always choose Series manually</EN>
+    <FR>Toujours choisir les séries manuellement</FR>
+    <EN>Always choose series manually</EN>
 </T0151>
 </configuration>

--- a/src/BDTranslations.Config
+++ b/src/BDTranslations.Config
@@ -405,8 +405,8 @@
     <EN>** Comic book's synopsis not found !</EN>
 </T0101>
 <T0102>
-    <FR>Coller le lien BD du www.bedetheque.com</FR>
-    <EN>Paste Album Link from www.bedetheque.com</EN>
+    <FR>Coller le lien internet de l'album provenant de www.bedetheque.com</FR>
+    <EN>Paste comic book's web link from www.bedetheque.com</EN>
 </T0102>
 <T0103>
     <FR>Scrape directement un lien</FR>

--- a/src/BedethequeScraper2.py
+++ b/src/BedethequeScraper2.py
@@ -82,7 +82,7 @@ CBTitle = True
 CBSeries = True
 CBDefault = False
 CBRescrape = False
-AllowUserChoice = True
+AllowUserChoice = "2"
 PopUpEditionForm = False
 ARTICLES = "Le,La,Les,L',The"
 FORMATARTICLES = True
@@ -2046,7 +2046,7 @@ def LoadSetting():
     try:
         AllowUserChoice = ft(MySettings.Get("CBStop"))
     except Exception as e:
-        AllowUserChoice = True
+        AllowUserChoice = "2"
     try:
         ARTICLES = MySettings.Get("ARTICLES")
     except Exception as e:
@@ -2118,9 +2118,6 @@ def LoadSetting():
         CBWeb = True
         ShortWebLink = True
 
-    if AllowUserChoice == 2:
-        AllowUserChoice = True
-
     SaveSetting()
 
     aWord = Translate()
@@ -2176,7 +2173,12 @@ def SaveSetting():
     MySettings.Set("SerieResumeEverywhere", tf(SerieResumeEverywhere))
     MySettings.Set("AlwaysChooseSerie", tf(AlwaysChooseSerie))
     MySettings.Set("ONESHOTFORMAT", tf(ONESHOTFORMAT))
-    MySettings.Set("CBStop", tf(AllowUserChoice))
+    if AllowUserChoice == True:
+        MySettings.Set("CBStop",  "1")
+    elif AllowUserChoice == False:
+        MySettings.Set("CBStop",  "0")
+    elif AllowUserChoice == "2":
+        MySettings.Set("CBStop",  "2")
 
     MySettings.Save((__file__[:-len('BedethequeScraper2.py')] + "App.Config"))
 
@@ -2263,7 +2265,7 @@ class BDConfigForm(Form):
             [
                 ('Series', {'label': Trans(71), 'state': if_else(CBSeries, CheckState.Checked, CheckState.Unchecked)}),
                 ('Title', {'label': Trans(72), 'state': if_else(CBTitle, CheckState.Checked, CheckState.Unchecked)}),
-                ('Writer', {'label': Trans(76), 'state': if_else(CBWriter, CheckState.Checked, CheckState.Unchecked)}),
+                ('Writer', {'label': Trans(73), 'state': if_else(CBWriter, CheckState.Checked, CheckState.Unchecked)}),
                 ('Penciller', {'label': Trans(74), 'state': if_else(CBPenciller, CheckState.Checked, CheckState.Unchecked)}),
                 ('Colorist', {'label': Trans(75), 'state': if_else(CBColorist, CheckState.Checked, CheckState.Unchecked)}),
                 ('Letterer', {'label': Trans(76), 'state': if_else(CBLetterer, CheckState.Checked, CheckState.Unchecked)}),
@@ -2317,7 +2319,7 @@ class BDConfigForm(Form):
         self._TIMEOUT = System.Windows.Forms.TextBox()
         self._TIMEOUTS = System.Windows.Forms.TextBox()
         self._TIMEPOPUP = System.Windows.Forms.TextBox()
-        self._labelTIMEPOPUP = System.Windows.Forms.Label()
+        self._labelTIMEPOPUP = System.Windows.Forms.CheckBox()
         self._PadNumber = System.Windows.Forms.TextBox()
         self._labelPadNumber = System.Windows.Forms.Label()
         self._CBRescrape = System.Windows.Forms.CheckBox()
@@ -2357,10 +2359,8 @@ class BDConfigForm(Form):
         self._tabPage1.Controls.Add(self._AlwaysChooseSerie)
         self._tabPage1.Controls.Add(self._TIMEOUT)
         self._tabPage1.Controls.Add(self._TIMEOUTS)
-        self._tabPage1.Controls.Add(self._TIMEPOPUP)
-        self._tabPage1.Controls.Add(self._labelTIMEPOPUP)
-        self._tabPage1.Controls.Add(self._PadNumber)
-        self._tabPage1.Controls.Add(self._labelPadNumber)
+        self._labelChoice.Controls.Add(self._TIMEPOPUP)
+        self._labelChoice.Controls.Add(self._labelTIMEPOPUP)
         self._tabPage1.Controls.Add(self._labelTIMEOUT)
         self._tabPage1.Controls.Add(self._labelTIMEOUTS)
         self._tabPage1.Controls.Add(self._CBRescrape)
@@ -2391,6 +2391,8 @@ class BDConfigForm(Form):
         self._tabPage2.Controls.Add(self._SerieResumeEverywhere)
         self._tabPage2.Controls.Add(self._SUBPATT)
         self._tabPage2.Controls.Add(self._labelSUBPATT)
+        self._tabPage2.Controls.Add(self._PadNumber)
+        self._tabPage2.Controls.Add(self._labelPadNumber)
         self._tabPage2.Location = System.Drawing.Point(4, 22)
         self._tabPage2.Name = "tabPage2"
         self._tabPage2.Padding = System.Windows.Forms.Padding(3)
@@ -2502,9 +2504,9 @@ class BDConfigForm(Form):
         #
         self._ButtonCheckNone.BackColor = System.Drawing.Color.FromArgb(255, 192, 128)
         self._ButtonCheckNone.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
-        self._ButtonCheckNone.Location = System.Drawing.Point(8, 308)
+        self._ButtonCheckNone.Location = System.Drawing.Point(8, 300)
         self._ButtonCheckNone.Name = "ButtonCheckNone"
-        self._ButtonCheckNone.Size = System.Drawing.Size(120, 20)
+        self._ButtonCheckNone.Size = System.Drawing.Size(120, 28)
         self._ButtonCheckNone.TabIndex = 53
         self._ButtonCheckNone.Text = Trans(94)
         self._ButtonCheckNone.UseVisualStyleBackColor = False
@@ -2515,9 +2517,9 @@ class BDConfigForm(Form):
         #
         self._ButtonCheckAll.BackColor = System.Drawing.Color.FromArgb(255, 192, 128)
         self._ButtonCheckAll.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
-        self._ButtonCheckAll.Location = System.Drawing.Point(132, 308)
+        self._ButtonCheckAll.Location = System.Drawing.Point(132, 300)
         self._ButtonCheckAll.Name = "ButtonCheckAll"
-        self._ButtonCheckAll.Size = System.Drawing.Size(120, 20)
+        self._ButtonCheckAll.Size = System.Drawing.Size(120, 28)
         self._ButtonCheckAll.TabIndex = 52
         self._ButtonCheckAll.Text = Trans(117)
         self._ButtonCheckAll.UseVisualStyleBackColor = False
@@ -2552,7 +2554,7 @@ class BDConfigForm(Form):
         self._DBGLOGMAX.Size = System.Drawing.Size(40, 23)
         self._DBGLOGMAX.TabIndex = 4
         self._DBGLOGMAX.TextAlign = HorizontalAlignment.Center
-        self._DBGLOGMAX.Text = str(int(DBGLOGMAX / 1024 / 1024))
+        self._DBGLOGMAX.Text = "{:.2f}".format(float(DBGLOGMAX) / (1024 * 1024))
         #
         # labelArticles
         #
@@ -2588,23 +2590,25 @@ class BDConfigForm(Form):
         self._SUBPATT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
         self._SUBPATT.Location = System.Drawing.Point(480, 206)
         self._SUBPATT.Name = "PATTSUB"
-        self._SUBPATT.Size = System.Drawing.Size(116, 20)
+        self._SUBPATT.Size = System.Drawing.Size(116, 24)
         self._SUBPATT.TabIndex = 101
         self._SUBPATT.Text = SUBPATT
         #
-        # label time out popup
+        # CB time out popup
         #
         self._labelTIMEPOPUP.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelTIMEPOPUP.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelTIMEPOPUP.Location = System.Drawing.Point(320, 246)
+        self._labelTIMEPOPUP.Location = System.Drawing.Point(16, 52)
         self._labelTIMEPOPUP.Name = "labelTimePopup"
-        self._labelTIMEPOPUP.Size = System.Drawing.Size(200, 23)
+        self._labelTIMEPOPUP.Size = System.Drawing.Size(310, 23)
         self._labelTIMEPOPUP.TabIndex = 102
+        self._labelTIMEPOPUP.UseVisualStyleBackColor = True
         self._labelTIMEPOPUP.Text = Trans(44)
+        self._labelTIMEPOPUP.CheckState = if_else(AllowUserChoice == "2", CheckState.Checked, CheckState.Unchecked)
         #
         # time out popup
         #
-        self._TIMEPOPUP.Location = System.Drawing.Point(550, 244)
+        self._TIMEPOPUP.Location = System.Drawing.Point(330, 54)
         self._TIMEPOPUP.Name = "TIMEPOPUP"
         self._TIMEPOPUP.Size = System.Drawing.Size(40, 20)
         self._TIMEPOPUP.TabIndex = 103
@@ -2616,19 +2620,19 @@ class BDConfigForm(Form):
         #
         self._labelPadNumber.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelPadNumber.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelPadNumber.Location = System.Drawing.Point(8, 274)
+        self._labelPadNumber.Location = System.Drawing.Point(268, 240)
         self._labelPadNumber.Name = "labelPadNumber"
-        self._labelPadNumber.Size = System.Drawing.Size(260, 23)
+        self._labelPadNumber.Size = System.Drawing.Size(300, 24)
         self._labelPadNumber.TabIndex = 104
         self._labelPadNumber.Text = Trans(148)
         #
         # pad number
         #
-        self._PadNumber.Location = System.Drawing.Point(268, 272)
+        self._PadNumber.Location = System.Drawing.Point(572, 238)
         self._PadNumber.Name = "PadNumber"
-        self._PadNumber.Size = System.Drawing.Size(40, 20)
+        self._PadNumber.Size = System.Drawing.Size(20, 24)
         self._PadNumber.TabIndex = 105
-        self._PadNumber.MaxLength = 3
+        self._PadNumber.MaxLength = 1
         self._PadNumber.TextAlign = HorizontalAlignment.Center
         self._PadNumber.Text = PadNumber
         #
@@ -2649,12 +2653,12 @@ class BDConfigForm(Form):
         self._RENLOGMAX.Size = System.Drawing.Size(40, 23)
         self._RENLOGMAX.TabIndex = 5
         self._RENLOGMAX.TextAlign = HorizontalAlignment.Center
-        self._RENLOGMAX.Text = str(int(RENLOGMAX / 1024 / 1024))
+        self._RENLOGMAX.Text = "{:.2f}".format(float(RENLOGMAX) / (1024 * 1024))
         #
         # CBRescrape
         #
         self._CBRescrape.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBRescrape.Location = System.Drawing.Point(8, 302)
+        self._CBRescrape.Location = System.Drawing.Point(8, 310)
         self._CBRescrape.Name = "CBRescrape"
         self._CBRescrape.Size = System.Drawing.Size(400, 20)
         self._CBRescrape.TabIndex = 21
@@ -2733,14 +2737,14 @@ class BDConfigForm(Form):
         self._labelChoice.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelChoice.Location = System.Drawing.Point(8, 192)
         self._labelChoice.Name = "labelChoice"
-        self._labelChoice.Size = System.Drawing.Size(420, 40)
+        self._labelChoice.Size = System.Drawing.Size(590, 82)
         self._labelChoice.Text = Trans(141)
         self._labelChoice.Tag = "Label"
         #
         # radioChoiceSkip (no user choice allowed)
         #
         self._radioChoiceSkip.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
-        self._radioChoiceSkip.Location = System.Drawing.Point(16, 16)
+        self._radioChoiceSkip.Location = System.Drawing.Point(16, 20)
         self._radioChoiceSkip.Name = "radioChoiceSkip"
         self._radioChoiceSkip.Size = System.Drawing.Size(200, 24)
         self._radioChoiceSkip.Text = Trans(45)
@@ -2749,7 +2753,7 @@ class BDConfigForm(Form):
         # radioChoiceUser (no user choice allowed)
         #
         self._radioChoiceUser.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
-        self._radioChoiceUser.Location = System.Drawing.Point(220, 16)
+        self._radioChoiceUser.Location = System.Drawing.Point(220, 20)
         self._radioChoiceUser.Name = "radioChoiceUser"
         self._radioChoiceUser.Size = System.Drawing.Size(200, 24)
         self._radioChoiceUser.Text = Trans(46)
@@ -2787,7 +2791,7 @@ class BDConfigForm(Form):
         #
         self._labelTIMEOUT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelTIMEOUT.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelTIMEOUT.Location = System.Drawing.Point(320, 274)
+        self._labelTIMEOUT.Location = System.Drawing.Point(320, 282)
         self._labelTIMEOUT.Name = "labelTIMEOUT"
         self._labelTIMEOUT.Size = System.Drawing.Size(200, 23)
         self._labelTIMEOUT.TabIndex = 99
@@ -2795,7 +2799,7 @@ class BDConfigForm(Form):
         #
         # TIMEOUT
         #
-        self._TIMEOUT.Location = System.Drawing.Point(550, 272)
+        self._TIMEOUT.Location = System.Drawing.Point(550, 280)
         self._TIMEOUT.Name = "TIMEOUT"
         self._TIMEOUT.Size = System.Drawing.Size(40, 20)
         self._TIMEOUT.TabIndex = 29
@@ -2807,7 +2811,7 @@ class BDConfigForm(Form):
         #
         self._labelTIMEOUTS.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelTIMEOUTS.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelTIMEOUTS.Location = System.Drawing.Point(8, 246)
+        self._labelTIMEOUTS.Location = System.Drawing.Point(8, 282)
         self._labelTIMEOUTS.Name = "labelTIMEOUTS"
         self._labelTIMEOUTS.Size = System.Drawing.Size(260, 23)
         self._labelTIMEOUTS.TabIndex = 99
@@ -2815,7 +2819,7 @@ class BDConfigForm(Form):
         #
         # TIMEOUTS
         #
-        self._TIMEOUTS.Location = System.Drawing.Point(268, 244)
+        self._TIMEOUTS.Location = System.Drawing.Point(268, 280)
         self._TIMEOUTS.Name = "TIMEOUTS"
         self._TIMEOUTS.Size = System.Drawing.Size(40, 20)
         self._TIMEOUTS.TabIndex = 30
@@ -2942,8 +2946,8 @@ class BDConfigForm(Form):
             SHOWRENLOG = if_else(self._SHOWRENLOG.CheckState == CheckState.Checked, True, False)
             SHOWDBGLOG = if_else(self._SHOWDBGLOG.CheckState == CheckState.Checked, True, False)
             DBGONOFF = if_else(self._DBGONOFF.CheckState == CheckState.Checked, True, False)
-            DBGLOGMAX = int(self._DBGLOGMAX.Text)*1024*1024
-            RENLOGMAX = int(self._RENLOGMAX.Text)*1024*1024
+            DBGLOGMAX = int(float(self._DBGLOGMAX.Text)*1024*1024)
+            RENLOGMAX = int(float(self._RENLOGMAX.Text)*1024*1024)
             LANGENFR = if_else(self._radioENG.Checked,"EN", "FR")
             TBTags = self._TBTags.Text
             ShortWebLink = if_else(self._ShortWebLink.CheckState == CheckState.Checked, True, False)
@@ -2956,7 +2960,7 @@ class BDConfigForm(Form):
             CBCount = if_else(self._scrapedData['Count']['state'] == CheckState.Checked, True, False)
             CBSynopsys = if_else(self._scrapedData['Synopsys']['state'] == CheckState.Checked, True, False)
             CBImprint = if_else(self._scrapedData['Imprint']['state'] == CheckState.Checked, True, False)
-            CBLetterer = if_else(self._scrapedData['Web']['state'] == CheckState.Checked, True, False)
+            CBLetterer = if_else(self._scrapedData['Letterer']['state'] == CheckState.Checked, True, False)
             CBPrinted = if_else(self._scrapedData['Printed']['state'] == CheckState.Checked, True, False)
             CBRating = if_else(self._scrapedData['Rating']['state'] == CheckState.Checked, True, False)
             CBISBN = if_else(self._scrapedData['ISBN']['state'] == CheckState.Checked, True, False)
@@ -2971,6 +2975,13 @@ class BDConfigForm(Form):
             CBDefault = if_else(self._CBDefault.CheckState == CheckState.Checked, True, False)
             CBRescrape = if_else(self._CBRescrape.CheckState == CheckState.Checked, True, False)
             AllowUserChoice = if_else(self._radioChoiceUser.Checked, True, False)
+            if self._radioChoiceUser.Checked:
+                if self._labelTIMEPOPUP.CheckState == CheckState.Checked:
+                    AllowUserChoice = "2"
+                else:
+                    AllowUserChoice = True
+            else:
+                AllowUserChoice = False
 
             ARTICLES = self._ARTICLES.Text
             SUBPATT = self._SUBPATT.Text
@@ -3021,23 +3032,11 @@ class BDConfigForm(Form):
         elif sender.Name.CompareTo(self._ButtonCheckNone.Name) == 0:
             for index in range(self._ScrapedDataCheckedListBox.Items.Count):
                 self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Unchecked)
-                if index == self._scrapedData.keys().index('Web'):
-                    self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Unchecked)
         elif sender.Name.CompareTo(self._ButtonCheckAll.Name) == 0:
             for index in range(self._ScrapedDataCheckedListBox.Items.Count):
                 self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Checked)
-                if index == self._scrapedData.keys().index('Web'):
-                    self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Checked)
 
     def ScrapedDataCheckedListBox_CheckItem(self, sender, e):
-        # Override behavior for some checkbox for example if we want a threestate checkbox
-        # if e.Index == self._scrapedData.keys().index('Web'):
-            # if e.CurrentValue == CheckState.Checked:
-            #     e.NewValue = CheckState.Indeterminate
-            # elif e.CurrentValue == CheckState.Indeterminate:
-            #     e.NewValue = CheckState.Unchecked
-            # else:
-            #     e.NewValue = CheckState.Checked
         self._scrapedData[self._scrapedData.keys()[e.Index]]['state'] = e.NewValue
 
 def Translate():
@@ -3144,7 +3143,7 @@ class SeriesForm(Form):
         self._OKButton = System.Windows.Forms.Button()
         self._ClearButton = System.Windows.Forms.Button()
 
-        if AllowUserChoice and TIMEPOPUP != "0":
+        if AllowUserChoice == "2":
             TimerExpired = False
             self._timer1 = System.Windows.Forms.Timer()
             self._timer1.Interval = int(TIMEPOPUP) * 1000
@@ -3249,7 +3248,7 @@ class SeriesForm(Form):
         # Adjust DPI scaling in this form
         HighDpiHelper.AdjustControlImagesDpiScale(self)
 
-        if AllowUserChoice and TIMEPOPUP != "0":
+        if AllowUserChoice == "2":
             self._timer1.Start()
 
     def fillList(self, ):

--- a/src/BedethequeScraper2.py
+++ b/src/BedethequeScraper2.py
@@ -19,8 +19,7 @@
 from __future__ import unicode_literals
 
 import clr, sys, re, os, System
-import operator
-
+import operator, collections
 from datetime import datetime, timedelta
 from time import strftime, clock
 
@@ -65,6 +64,7 @@ CBStatus = True
 CBGenre = True
 CBNotes = True
 CBWeb = True
+ShortWebLink = False
 CBCount = True
 CBSynopsys = True
 CBImprint = True
@@ -82,7 +82,7 @@ CBTitle = True
 CBSeries = True
 CBDefault = False
 CBRescrape = False
-CBStop = "2"
+AllowUserChoice = True
 PopUpEditionForm = False
 ARTICLES = "Le,La,Les,L',The"
 FORMATARTICLES = True
@@ -112,165 +112,158 @@ RAW_STR = re.compile(RAW_STR_PATTERN)
 
 ########################################
 # Info Serie
-SERIE_LIST_PATTERN = r'<a\shref=\"https\:\/\/www.bedetheque.com\/serie-(.*?)\">.*?libelle\">(.*?)\r'
+SERIE_LIST_PATTERN = r'<a\shref="https://www.bedetheque.com/serie-(.*?)">.*?libelle">(.*?)\r'
 
 SERIE_LIST_CHECK_PATTERN = r's.ries\strouv.{20,60}?La\srecherche.*?\srenvoie\splus\sde\s500\sdonn'
 SERIE_LIST_CHECK = re.compile(SERIE_LIST_CHECK_PATTERN, re.IGNORECASE | re.DOTALL)
 
-SERIE_URL_PATTERN = r'<a\shref=\"(.*?)\">\r\n.{50,60}<span\sclass=\"libelle\">%s\s*?</span>'
+SERIE_URL_PATTERN = r'<a\shref="(.*?)">\r\n.{50,60}<span\sclass="libelle">%s\s*?</span>'
 
-ALBUM_ID_PATTERN = r'id=\"%s\".*?album-%s(.*?)\.html'
-ALBUM_INFO_PATTERN = r'<meta\sname=\"description\"\scontent="(.*?)\"'
+ALBUM_ID_PATTERN = r'id="%s".*?album-%s(.*?)\.html'
+ALBUM_INFO_PATTERN = r'<meta\sname="description"\scontent="(.*?)"'
 
-SERIE_LANGUE_PATTERN = r'class=\"flag\"/>(.*?)</span>'
+SERIE_LANGUE_PATTERN = r'class="flag"/>(.*?)</span>'
 SERIE_LANGUE = re.compile(SERIE_LANGUE_PATTERN, re.IGNORECASE)
 
-SERIE_GENRE_PATTERN = r'<span\sclass=\"style\">(.*?)<'
+SERIE_GENRE_PATTERN = r'<span\sclass="style">(.*?)<'
 SERIE_GENRE = re.compile(SERIE_GENRE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-SERIE_RESUME_PATTERN = r'<meta\sname=\"description\"\scontent=\"(.*?)"\s/>'
+SERIE_RESUME_PATTERN = r'<meta\sname="description"\scontent="(.*?)"\s/>'
 SERIE_RESUME = re.compile(SERIE_RESUME_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-SERIE_STATUS_PATTERN = r'<h3>.*?<span><i\sclass=\"icon-info-sign\"></i>(.*?)</span>'
+SERIE_STATUS_PATTERN = r'<h3>.*?<span><i\sclass="icon-info-sign"></i>(.*?)</span>'
 SERIE_STATUS = re.compile(SERIE_STATUS_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-SERIE_NOTE_PATTERN = r'<p\sclass=\"static\">Note:\s<strong>\s(?P<note>[^<]*?)</strong>'
+SERIE_NOTE_PATTERN = r'<p\sclass="static">Note:\s<strong>\s(?P<note>[^<]*?)</strong>'
 SERIE_NOTE = re.compile(SERIE_NOTE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-SERIE_COUNT_PATTERN = r'class=\"icon-book\"></i>\s(\d+)'
+SERIE_COUNT_PATTERN = r'class="icon-book"></i>\s(\d+)'
 SERIE_COUNT = re.compile(SERIE_COUNT_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 SERIE_COUNT_REAL_PATTERN = r'liste-albums-side(.*?)WIDGET'
 SERIE_COUNT_REAL = re.compile(SERIE_COUNT_REAL_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 SERIE_COUNTOF_PATTERN = r'<label>(.*?)<span'
-SERIE_COUNTOF = re.compile(SERIE_COUNTOF_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)                    
+SERIE_COUNTOF = re.compile(SERIE_COUNTOF_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 SERIE_HEADER2_PATTERN = r'<h3(.+?)</p'
-SERIE_HEADER2 = re.compile(SERIE_HEADER2_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+SERIE_HEADER2 = re.compile(SERIE_HEADER2_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 # Info Serie for Quickscrape
 
-SERIE_QSERIE_PATTERN = r'>(.*?)</h'
+SERIE_QSERIE_PATTERN = r'<h1>\s*<a href="(https://www.bedetheque.com[^\.]+\.html)"\stitle="([^"]+)">'
 
 # Info Album from Album
-INFO_SERIENAMENUMBER_ALBUM_PATTERN = r'<span\sclass=\"type\">S.*?rie\s:\s</span>\s?(.*?)<.*?id=\"%s\">.*?<div\sclass=\"titre\">(?:(.*?)<.*?numa\">(.*?)</span>\.?\s?)?(.*?)<'
+INFO_SERIENAMENUMBER_ALBUM_PATTERN = r'<span\sclass="type">S.*?rie\s:\s</span>\s?(.*?)<.*?id="%s">.*?<div\sclass="titre">(?:(.*?)<.*?numa">(.*?)</span>\.?\s?)?(.*?)<'
 
-ALBUM_BDTHEQUE_NOTNUM_PATTERN = r'tails\">.*?<span\sclass=\"numa"></span>.*?<a name=\"(.*?)\"'            
+ALBUM_BDTHEQUE_NOTNUM_PATTERN = r'tails">.*?<span\sclass="numa"></span>.*?<a name="(.*?)"'
 ALBUM_BDTHEQUE_NOTNUM = re.compile(ALBUM_BDTHEQUE_NOTNUM_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_TITLE_PATTERN = r'itemprop=\"url\"\shref=\"%s\"\stitle=\"(.*?)\">'
+ALBUM_TITLE_PATTERN = r'itemprop="url"\shref="%s"\stitle="(.*?)">'
 
-ALBUM_EVAL_PATTERN = r'ratingValue\">(.*?)<'
-ALBUM_EVAL = re.compile(ALBUM_EVAL_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_EVAL_PATTERN = r'ratingValue">(.*?)<'
+ALBUM_EVAL = re.compile(ALBUM_EVAL_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 
-ALBUM_SCENAR_MULTI_AUTHOR_PATTERN = r'<label>sc.*?nario\s:</label>.*?(?=\">)(.*?)<label>[^\&]' #Dessin'
-ALBUM_SCENAR_MULTI_AUTHOR = re.compile(ALBUM_SCENAR_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_SCENAR_MULTI_AUTHOR_PATTERN = r'<label>sc.*?nario\s:</label>.*?(?=">)(.*?)<label>[^&]' #Dessin'
+ALBUM_SCENAR_MULTI_AUTHOR = re.compile(ALBUM_SCENAR_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_SCENAR_MULTI_AUTHOR_NAMES_PATTERN = r'\">(.*?)</'
-ALBUM_SCENAR_MULTI_AUTHOR_NAMES = re.compile(ALBUM_SCENAR_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_SCENAR_MULTI_AUTHOR_NAMES_PATTERN = r'">(.*?)</'
+ALBUM_SCENAR_MULTI_AUTHOR_NAMES = re.compile(ALBUM_SCENAR_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_STORYBOARD_MULTI_AUTHOR_PATTERN = r'label>storyboard\s:.*?itemprop.*?\">(.*?)<'
-ALBUM_STORYBOARD_MULTI_AUTHOR = re.compile(ALBUM_STORYBOARD_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_STORYBOARD_MULTI_AUTHOR_PATTERN = r'label>storyboard\s:.*?itemprop.*?">(.*?)<'
+ALBUM_STORYBOARD_MULTI_AUTHOR = re.compile(ALBUM_STORYBOARD_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_STORYBOARD_MULTI_AUTHOR_NAMES_PATTERN = r'<label>.*?\">(.*?)</a'
-ALBUM_STORYBOARD_MULTI_AUTHOR_NAMES = re.compile(ALBUM_STORYBOARD_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_STORYBOARD_MULTI_AUTHOR_NAMES_PATTERN = r'<label>.*?">(.*?)</a'
+ALBUM_STORYBOARD_MULTI_AUTHOR_NAMES = re.compile(ALBUM_STORYBOARD_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_SCENAR_PATTERN = r'<label>sc.*?nario\s:</label>.*?>(.*?)<'
-ALBUM_SCENAR = re.compile(ALBUM_SCENAR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_SCENAR = re.compile(ALBUM_SCENAR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_DESSIN_MULTI_AUTHOR_PATTERN = r'<label>dessin\s:</label>.*?(?=\">)(.*?)<label>[^\&]'
-ALBUM_DESSIN_MULTI_AUTHOR = re.compile(ALBUM_DESSIN_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_DESSIN_MULTI_AUTHOR_PATTERN = r'<label>dessin\s:</label>.*?(?=">)(.*?)<label>[^&]'
+ALBUM_DESSIN_MULTI_AUTHOR = re.compile(ALBUM_DESSIN_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_DESSIN_MULTI_AUTHOR_NAMES_PATTERN = r'\">(.*?)</'
-ALBUM_DESSIN_MULTI_AUTHOR_NAMES = re.compile(ALBUM_DESSIN_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_DESSIN_MULTI_AUTHOR_NAMES_PATTERN = r'">(.*?)</'
+ALBUM_DESSIN_MULTI_AUTHOR_NAMES = re.compile(ALBUM_DESSIN_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_DESSIN_PATTERN = r'<label>dessin\s:</label>.*?>(.*?)<'
-ALBUM_DESSIN = re.compile(ALBUM_DESSIN_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_DESSIN = re.compile(ALBUM_DESSIN_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_COLOR_MULTI_AUTHOR_PATTERN = r'<label>couleurs\s:</label>.*?(?=\">)(.*?)<label>[^\&]'
-ALBUM_COLOR_MULTI_AUTHOR = re.compile(ALBUM_COLOR_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COLOR_MULTI_AUTHOR_PATTERN = r'<label>couleurs\s:</label>.*?(?=">)(.*?)<label>[^&]'
+ALBUM_COLOR_MULTI_AUTHOR = re.compile(ALBUM_COLOR_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_COLOR_MULTI_AUTHOR_NAMES_PATTERN = r'\">(.*?)</'
-ALBUM_COLOR_MULTI_AUTHOR_NAMES = re.compile(ALBUM_COLOR_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COLOR_MULTI_AUTHOR_NAMES_PATTERN = r'">(.*?)</'
+ALBUM_COLOR_MULTI_AUTHOR_NAMES = re.compile(ALBUM_COLOR_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_COLOR_PATTERN = r'<label>Couleurs\s:</label>.*?">(.*?)<'
-ALBUM_COLOR = re.compile(ALBUM_COLOR_PATTERN,  re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COLOR = re.compile(ALBUM_COLOR_PATTERN,  re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_COUVERT_MULTI_AUTHOR_PATTERN = r'<label>couverture\s:</label>.*?(?=\">)(.*?)<label>[^\&]'
-ALBUM_COUVERT_MULTI_AUTHOR = re.compile(ALBUM_COUVERT_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COUVERT_MULTI_AUTHOR_PATTERN = r'<label>couverture\s:</label>.*?(?=">)(.*?)<label>[^&]'
+ALBUM_COUVERT_MULTI_AUTHOR = re.compile(ALBUM_COUVERT_MULTI_AUTHOR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_COUVERT_MULTI_AUTHOR_NAMES_PATTERN = r'\">(.*?)</'
-ALBUM_COUVERT_MULTI_AUTHOR_NAMES = re.compile(ALBUM_COUVERT_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COUVERT_MULTI_AUTHOR_NAMES_PATTERN = r'">(.*?)</'
+ALBUM_COUVERT_MULTI_AUTHOR_NAMES = re.compile(ALBUM_COUVERT_MULTI_AUTHOR_NAMES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_COUVERT_PATTERN = r'<label>couverture\s:</label>.*?>(.*?)<'
-ALBUM_COUVERT = re.compile(ALBUM_COUVERT_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COUVERT = re.compile(ALBUM_COUVERT_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_LETTRAGE_PATTERN = r'<label>Lettrage\s:\s?</label>.*?\">(.+?)</'
-ALBUM_LETTRAGE = re.compile(ALBUM_LETTRAGE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_LETTRAGE_PATTERN = r'<label>Lettrage\s:\s?</label>.*?">(.+?)</'
+ALBUM_LETTRAGE = re.compile(ALBUM_LETTRAGE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_DEPOT_PATTERN = r'<label>D.pot L.gal\s:\s?</label>(?P<month>[\d|-]{0,2})[\/]?(?P<year>[\d]{2,4})?'
-ALBUM_DEPOT = re.compile(ALBUM_DEPOT_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_DEPOT_PATTERN = r'<label>D.pot L.gal\s:\s?</label>(?P<month>[\d|-]{0,2})/?(?P<year>[\d]{2,4})?'
+ALBUM_DEPOT = re.compile(ALBUM_DEPOT_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_ACHEVE_PATTERN = r'<label>Achev.*?\s:\s?</label>(?P<month>[\d|-]{0,2})[\/]?(?P<year>[\d]{2,4})?<'
-ALBUM_ACHEVE = re.compile(ALBUM_ACHEVE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_ACHEVE_PATTERN = r'<label>Achev.*?\s:\s?</label>(?P<month>[\d|-]{0,2})/?(?P<year>[\d]{2,4})?<'
+ALBUM_ACHEVE = re.compile(ALBUM_ACHEVE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_EDITEUR_PATTERN = r'<label>Editeur\s:\s?</label>(.*?)</'
-ALBUM_EDITEUR = re.compile(ALBUM_EDITEUR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_EDITEUR = re.compile(ALBUM_EDITEUR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_COLLECTION_PATTERN = r'<label>Collection\s:\s?</label>.*?\">(.*?)</'
-ALBUM_COLLECTION = re.compile(ALBUM_COLLECTION_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COLLECTION_PATTERN = r'<label>Collection\s:\s?</label>.*?">(.*?)</'
+ALBUM_COLLECTION = re.compile(ALBUM_COLLECTION_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_TAILLE_PATTERN = r'<label>Format\s:\s?</label>.*?(.+?)</'
-ALBUM_TAILLE = re.compile(ALBUM_TAILLE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_TAILLE = re.compile(ALBUM_TAILLE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_ISBN_PATTERN = r"<label>.*?ISBN\s:\s</label.*?>([^<]*?)</"
-ALBUM_ISBN = re.compile(ALBUM_ISBN_PATTERN, re.IGNORECASE | re.DOTALL)    
+ALBUM_ISBN_PATTERN = r'<label>.*?ISBN\s:\s</label.*?>([^<]*?)</'
+ALBUM_ISBN = re.compile(ALBUM_ISBN_PATTERN, re.IGNORECASE | re.DOTALL)
 
 ALBUM_PLANCHES_PATTERN = r'<label>Planches\s:\s?</label>(\d*?)</'
-ALBUM_PLANCHES = re.compile(ALBUM_PLANCHES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_PLANCHES = re.compile(ALBUM_PLANCHES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_COVER_PATTERN = r'<meta\sproperty=\"og:title\".*?=\"https:(.*?)\"'
-ALBUM_COVER = re.compile(ALBUM_COVER_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_COVER_PATTERN = r'<meta\sproperty="og:title".*?="https:(.*?)"'
+ALBUM_COVER = re.compile(ALBUM_COVER_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-ALBUM_RESUME_PATTERN = r'<meta\sname=\"description\"\scontent=\"(.*?)\"'
-ALBUM_RESUME = re.compile(ALBUM_RESUME_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_RESUME_PATTERN = r'<meta\sname="description"\scontent="(.*?)"'
+ALBUM_RESUME = re.compile(ALBUM_RESUME_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ALBUM_INFOEDITION_PATTERN = r'<em>Info\s.*?dition\s:\s?</em>\s?(.*?)<'
-ALBUM_INFOEDITION = re.compile(ALBUM_INFOEDITION_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+ALBUM_INFOEDITION = re.compile(ALBUM_INFOEDITION_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
-#modif kiwi
-#ALBUM_URL_PATTERN = r'<label>%s<span\sclass=\"numa.*?\.%s<.*?<a\shref=\"(.*?)"'
-#ALBUM_URL_PATTERN = r'<label>%s<span\sclass=\"numa.*?\.<.*?<a\shref=\"(.*?)"'
-ALBUM_URL_PATTERN = r'<label>%s<span\sclass=\"numa.*?\.<.*?<a\shref=\"(.*?)"\s.*?title=.+?\">(.+?)</'
+ALBUM_URL_PATTERN = r'<label>%s<span\sclass="numa.*?\.<.*?<a\shref="(.*?)"\s.*?title=.+?">(.+?)</'
 
-ALBUM_SINGLE_URL_PATTERN = r'<label>%s<span\sclass=\"numa.*?\.%s<.*?<a\shref=\"(.*?)\#(.*?)\"'
+ALBUM_SINGLE_URL_PATTERN = r'<label>%s<span\sclass="numa.*?\.%s<.*?<a\shref="(.*?)\#(.*?)"'
 
-#modif kiwi
-#ALBUM_NON_NUM_URL_PATTERN = r'<label><span\sclass=\"numa\">%s</span>.*?\.<.*?<a\shref=\"(.*?)"'   
-ALBUM_NON_NUM_URL_PATTERN = r'<label><span\sclass=\"numa\">%s</span>.*?\.<.*?<a\shref=\"(.*?)"\s.*?title=.+?\">(.+?)</'  
+ALBUM_NON_NUM_URL_PATTERN = r'<label><span\sclass="numa">%s</span>.*?\.<.*?<a\shref="(.*?)"\s.*?title=.+?">(.+?)</'  
 
 ALBUM_SINGLEALBUM_URLALL_PATTERN = r'<h3>(.*?)</h3>'
 ALBUM_SINGLEALBUM_URLALL = re.compile(ALBUM_SINGLEALBUM_URLALL_PATTERN, re.DOTALL | re.IGNORECASE)
 
-ALBUM_SINGLEALBUM_URL_PATTERN = r'href=\"(.*?)\"\stitle.*?\">.*?%s<span\sclass=\"numa\">%s<'
+ALBUM_SINGLEALBUM_URL_PATTERN = r'href="(.*?)"\stitle.*?">.*?%s<span\sclass="numa">%s<'
 
-ALBUMDETAILS_URL_PATTERN = r'https:\/\/www.bedetheque.com\/album-%s-(.*?)\"'
-ALBUMDETAILSSINGLE_URL_PATTERN = r'https:\/\/www.bedetheque.com\/album-(.*?)\"'
+ALBUMDETAILS_URL_PATTERN = r'https://www.bedetheque.com/album-%s-(.*?)"'
+ALBUMDETAILSSINGLE_URL_PATTERN = r'https://www.bedetheque.com/album-(.*?)"'
 
-ALBUM_URL_PATTERN_NOTNUM = r'<div\sclass=\"album.*?href=\"(.*?)\"'
-ALBUM_URL_NOTNUM = re.compile(ALBUM_URL_PATTERN_NOTNUM, re.MULTILINE | re.DOTALL | re.IGNORECASE)                
+ALBUM_URL_PATTERN_NOTNUM = r'<div\sclass="album.*?href="(.*?)"'
+ALBUM_URL_NOTNUM = re.compile(ALBUM_URL_PATTERN_NOTNUM, re.MULTILINE | re.DOTALL | re.IGNORECASE)
 
-#ALBUM_QNUM_PATTERN = r'<title>(.*?)\-(.*?)\-?\s(.*?)</title>'
-ALBUM_QNUM_PATTERN = r'og:title\"\scontent=\"(.*?)\-(.*?)\-?\s(.*?)\"\s*/>'
-#ALBUM_QNUM = re.compile(ALBUM_QNUM_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)            
-ALBUM_QNUM = re.compile(ALBUM_QNUM_PATTERN, re.IGNORECASE)        
+ALBUM_QNUM_PATTERN = r'og:title"\scontent="(.*?)-(.*?)-?\s(.*?)"\s*/>'
+ALBUM_QNUM = re.compile(ALBUM_QNUM_PATTERN, re.IGNORECASE)
 
-ALBUM_QTITLE_PATTERN = r'titre.*?%s<span.*?name\">(.*?)<'
+ALBUM_QTITLE_PATTERN = r'titre.*?%s<span.*?name">(.*?)<'
 ########################################
 # Info Revues
-REVUE_LIST_PATTERN = r'<a\shref=\"https\:\/\/www.bedetheque.com\/revue-(.*?)\">.*?libelle\">(.*?)\r'
+REVUE_LIST_PATTERN = r'<a\shref="https://www.bedetheque.com/revue-(.*?)">.*?libelle">(.*?)\r'
 
 REVUE_LIST_EXISTS_PATTERN = r'<h3>\d{1,3} revue\w?? trouvée\w??</h3>'
 REVUE_LIST_EXISTS = re.compile(REVUE_LIST_EXISTS_PATTERN, re.IGNORECASE | re.DOTALL)
@@ -278,7 +271,7 @@ REVUE_LIST_EXISTS = re.compile(REVUE_LIST_EXISTS_PATTERN, re.IGNORECASE | re.DOT
 REVUE_LIST_CHECK_PATTERN = r'<h1>Revues</h1>.*?La\srecherche\seffectu.*?\srenvoie\splus\sde\s.*?<h1>S.*?ries<'
 REVUE_LIST_CHECK = re.compile(REVUE_LIST_CHECK_PATTERN, re.IGNORECASE | re.DOTALL)
 
-REVUE_CALC_PATTERN = r'<option\svalue=\"(.{1,160}?)\">%s</'
+REVUE_CALC_PATTERN = r'<option\svalue="(.{1,160}?)">%s</'
 
 REVUE_HEADER_PATTERN = r'class="couv"(.{1,100}?couvertures"\shref="(https.{1,150}?)">.{1,600}?class="titre".{1,100}?#(%s)\..+?class="autres".+?)</li>'
 REVUE_HEADER_PATTERN_ALT = r'<a name="%s">.+?class="couv"(.{1,100}?couvertures"\shref="(https.{1,150}?)">.+?class="titre".{1,100}?#(.+?)\..+?class="autres".+?)</li>'
@@ -296,11 +289,11 @@ REVUE_PERIOD_PATTERN = r'<label>P.riodicit.\s:\s??</label>(.*?)</'
 REVUE_PERIOD = re.compile(REVUE_PERIOD_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 def BD_start(books):
-    
+
     global nRenamed, nIgnored, aWord
 
     aWord = Translate()
-    
+
     if not LoadSetting():
         return
 
@@ -331,9 +324,9 @@ def BD_start(books):
         if Result == DialogResult.No:
             return
 
-    if books:        
+    if books:
         WorkerThread(books)
-    
+
     else:
         if DBGONOFF:print Trans(15) +"\n"
         log_BD(Trans(15), "", 1)
@@ -346,14 +339,14 @@ def WorkerThread(books):
     t = Thread(ThreadStart(thread_proc))
 
     bError = False
-    
+
     Shadow1 = False
     Shadow2 = False
-    
+
     TimeStart = clock()
-    
+
     try:
-                
+
         f = ProgressBarDialog(books.Count)
         f.Show(ComicRack.MainWindow)
 
@@ -363,34 +356,33 @@ def WorkerThread(books):
         log_BD(Trans(7) + str(nOrigBooks) +  Trans(8), "\n============ " + str(datetime.now().strftime("%A %d %B %Y %H:%M:%S")) + " ===========", 0)
 
         i = 0
-        
+
         if DBGONOFF:print chr(10) + "=" * 25 + "- Begin! -" + "=" * 25 + chr(10)
 
         nTIMEDOUT = 0
         
         nBooks = len(books)
-#modif kiwi
         PickSeries = False
         serie_rech_prev = None
 
         for book in books:
-                        
+
             TimeBookStart = clock()
             if DBGONOFF:print "v" * 60
-                        
+
             if bStopit or (nTIMEDOUT == int(TIMEOUT)):
                 if bStopit and DBGONOFF:print "Cancelled from WorkerThread Start"
                 return
-            
+
             nTIMEDOUT += 1
-            
+
             if book.Number:
                 dlgNumber = book.Number
             else:
                 dlgNumber = book.ShadowNumber
                 Shadow2 = True
 
-            if book.Series:                
+            if book.Series:
                 dlgName = titlize(book.Series)
             else:
                 dlgName = book.ShadowSeries
@@ -404,18 +396,17 @@ def WorkerThread(books):
             dlgNameClean = cleanARTICLES(dlgName)
             dlgName = formatARTICLES(dlgName)
 
-#modif Pitoufos
             findCara = dlgName.find(SUBPATT)
             if findCara > 0 :
                 lenDlgName = len(dlgName)
                 totalchar = lenDlgName - findCara
                 dlgName = dlgName[:-totalchar]
 
-            mPos = re.search(r'([.|,|\\|\/])', dlgNumber)
+            mPos = re.search(r'([.,\\/])', dlgNumber)
             if not isnumeric(dlgNumber):
                 albumNum = dlgNumber
                 AlbumNumNum = False
-            elif isnumeric(dlgNumber) and not re.search(r'[.|,|\\|\/]', dlgNumber):
+            elif isnumeric(dlgNumber) and not re.search(r'[.,\\/]', dlgNumber):
                 dlgNumber = str(int(dlgNumber))
                 albumNum = str(int(dlgNumber))
                 AlbumNumNum = True
@@ -433,12 +424,12 @@ def WorkerThread(books):
             if bStopit:
                 if DBGONOFF:print "Cancelled from WorkerThread after Update"
                 return
-            
+
             RetAlb = False
             if CBRescrape:
-                if book.Web:                    
+                if book.Web:
                     RetAlb = QuickScrapeBD2(books, book, book.Web)
-                
+
             if not CBRescrape:
                 if DBGONOFF:print Trans(9) + dlgName + "\tNo = [" + albumNum + "]" + if_else(dlgAltNumber == '', '', '\tAltNo. = [' + dlgAltNumber + ']')
                 serieUrl = None
@@ -450,13 +441,13 @@ def WorkerThread(books):
                 if bStopit:
                     if DBGONOFF:print "Cancelled from WorkerThread after SetSerieId return"
                     return
-                
+
                 if serieUrl:
                     RetAlb = True
                     if not '/revue-' in serieUrl: 
                         LongSerie= serieUrl.lower().replace(".html", u'__10000.html')
-                        serieUrl = LongSerie            
-
+                        serieUrl = LongSerie
+                        
                     if AlbumNumNum:
                         if DBGONOFF:print Trans(11), albumNum + "]", if_else(dlgAltNumber == '', '', ' - AltNo.: ' + dlgAltNumber)
                     else:
@@ -465,38 +456,35 @@ def WorkerThread(books):
                     RetAlb = SetAlbumInformation(book, serieUrl, dlgName, albumNum)
 
                     #SkipAlbum utlisez seulement lorsque l'on appuye sur Annuler dans la fenetre pour choisir l'album ParseSerieInfo
-                    if not SkipAlbum and not RetAlb and not '/revue-' in serieUrl:                    
+                    if not SkipAlbum and not RetAlb and not '/revue-' in serieUrl:
                         # reading info on album when no album list is present (i.e. "Croisade (Seconde époque: Nomade)")
                         RetAlb = parseAlbumInfo (book, serieUrl, albumNum)
             
             if RetAlb:
-                nRenamed += 1                
+                nRenamed += 1
                 log_BD("[" + dlgName + "] " + dlgNumber + if_else(dlgAltNumber == '', '', ' AltNo.[' + dlgAltNumber + ']') + " - " + titlize(book.Title), Trans(13), 1)
             else:
                 nIgnored += 1
                 log_BD("[" + dlgName + "] " + dlgNumber + if_else(dlgAltNumber == '', '', ' AltNo. [' + dlgAltNumber + ']') + " - " + titlize(book.Title), Trans(14) + "\n", 1)
 
             i += 1
-            
+
             TimeBookEnd = clock()
             nSec = int(TimeBookEnd - TimeBookStart)
             if DBGONOFF:print Trans(125), str(timedelta(seconds=nSec)) + chr(10)
-            #if DBGONOFF:print Trans(125), "%.2g\"" % (TimeBookEnd - TimeBookStart)    + chr(10)
             if DBGONOFF:print "^" * 60
 
             # timeout in seconds before next scrape
             if TIMEOUTS and nOrigBooks > nIgnored + nRenamed:
                 cPause = Trans(140).replace("%%", str(TIMEOUTS))
                 f.Update(cPause, 0, False)
-                f.Refresh()                                
-                for i in range(20*int(TIMEOUTS)):                        
+                f.Refresh()
+                for i in range(20*int(TIMEOUTS)):
                     t.CurrentThread.Join(50)
                     Application.DoEvents()
                     if bStopit:
                         if DBGONOFF:print "Cancelled from WorkerThread TIMEOUT Loop"
                         return
-                #f.Update("[" + str(i + 1) + "/" + str(len(books)) + "] : " + dlgName + " - " + dlgNumber + if_else(dlgAltNumber == '', '', ' AltNo.[' + dlgAltNumber + ']') + " - " + titlize(book.Title), 0)
-                #f.Refresh()    
             if bStopit:
                 if DBGONOFF:print "Cancelled from WorkerThread End"
                 return
@@ -531,15 +519,14 @@ def WorkerThread(books):
                 if FileInfo(__file__[:-len('BedethequeScraper2.py')] + "BD2_Rename_Log.txt"):
                     Start(__file__[:-len('BedethequeScraper2.py')] + "BD2_Rename_Log.txt")
         else:
-            
-            TimeEnd = clock()            
-            #if DBGONOFF:print Trans(124), "%.2g\"" % (TimeEnd - TimeStart)
+
+            TimeEnd = clock()
             nSec = int(TimeEnd - TimeStart)
             if DBGONOFF:print Trans(124), str(timedelta(seconds=nSec)) 
             if DBGONOFF:print "=" * 25 + "- End! -" + "=" * 25 + chr(10)
             rdlg = MessageBox.Show(ComicRack.MainWindow, Trans(17) + str(nRenamed) + ", " + Trans(18) + str(nIgnored) + " (" + Trans(108) + str(nOrigBooks) + ")" , Trans(22), MessageBoxButtons.OK, MessageBoxIcon.Exclamation, MessageBoxDefaultButton.Button1)            
 
-        t.Abort()        
+        t.Abort()
 
         return
 
@@ -548,7 +535,6 @@ def SetSerieId(book, serie, num, nBooksIn):
     global ListSeries, NewLink, NewSeries, RenameSeries, PickSeries, PickSeriesLink, serie_rech_prev
     
     if serie:
-#modif kiwi
         if re.match("[a-z]", remove_accents(serie[0]).lower()):
             letter = remove_accents(serie[0])
         else:
@@ -556,11 +542,10 @@ def SetSerieId(book, serie, num, nBooksIn):
     else:
         return ""
 
-    
     urlN = "/bandes_dessinees_" + letter + ".html"
-    
+
     RenameSeries = False
-    
+
     try:
 
         serieUrl = ''
@@ -568,24 +553,23 @@ def SetSerieId(book, serie, num, nBooksIn):
         if DBGONOFF:print "AlwaysChooseSerie: " + str(AlwaysChooseSerie)
         if not AlwaysChooseSerie:
             request = _read_url(urlN.encode('utf-8'), False)
-    
+
             if bStopit:
                 if DBGONOFF:print "Cancelled from SetSerieId after letter page return"
                 return ''
-            
+
             if request:
                 RegCompile = re.compile(SERIE_URL_PATTERN % checkRegExp(serie.strip()),  re.IGNORECASE)
                 nameRegex = RegCompile.search(request)
-                    
+
                 if nameRegex:
-                    
+
                     serieUrl = nameRegex.group(1)
                     if not ".html" in serieUrl:serieUrl += ".html"
-    
+
                     if DBGONOFF:print Trans(23) + serieUrl
                     return serieUrl
 
-#modif kiwi
         serie_rech = remove_accents(serie.lower())
         if serie_rech == serie_rech_prev and PickSeries != False:
             serie_rech_prev = serie_rech
@@ -594,31 +578,30 @@ def SetSerieId(book, serie, num, nBooksIn):
         else:
             serie_rech_prev = serie_rech
             PickSeries = False
-            
+
         ListSeries = list()
-        if DBGONOFF:print "Nom de Série pour recherche = " + dlgNameClean                
+        if DBGONOFF:print "Nom de Série pour recherche = " + dlgNameClean
         urlN = '/search/tout?RechTexte=' + remove_accents(dlgNameClean.lower().strip()) +'&RechWhere=0'
 
         if DBGONOFF:print Trans(113), 'www.bedetheque.com' + urlN
-        
+
         request = _read_url(urlN.encode('utf-8'), False)
 
         if bStopit:
             if DBGONOFF:print "Cancelled from SetSerieId after Search return"
             return ''
-                        
-        #SERIE_LIST_CHECK = re.compile(SERIE_LIST_CHECK_PATTERN, re.IGNORECASE | re.DOTALL)                
+
         if SERIE_LIST_CHECK.search(request) or REVUE_LIST_CHECK.search(request):
             Result = MessageBox.Show(ComicRack.MainWindow, Trans(114) + '[' + titlize(book.Series) + '] !', Trans(2), MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
             if DBGONOFF:print Trans(114) + '[' + titlize(book.Series) + '] !'
             return ''
-        
+
         i = 1
         RegCompile = re.compile(SERIE_LIST_PATTERN, re.IGNORECASE | re.DOTALL )
         for seriepick in RegCompile.finditer(request):                        
             ListSeries.append(["serie-" + seriepick.group(1), checkWebChar(strip_tags(seriepick.group(2))), str(i).zfill(3)])
-            i = i + 1                                            
-            
+            i = i + 1
+
         RegCompile = re.compile(REVUE_LIST_PATTERN, re.IGNORECASE | re.DOTALL )
         if REVUE_LIST_EXISTS.search(request):
             for seriepick in RegCompile.finditer(request):
@@ -632,14 +615,13 @@ def SetSerieId(book, serie, num, nBooksIn):
             if DBGONOFF:print Trans(111) + (ListSeries[0][1])
             log_BD("** [" + serie + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com" + serieUrl + ")", Trans(25), 1)
             log_BD(Trans(111), "[" + ListSeries[0][1] + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com\\" + ListSeries[0][0] + ")", 1)
-            RenameSeries = ListSeries[0][1]                    
+            RenameSeries = ListSeries[0][1]
             return ListSeries[0][0]
 
-        elif len(ListSeries) > 1 or (AlwaysChooseSerie and len(ListSeries) >= 1) :    
-            if (CBStop == True or CBStop == "2") or nBooksIn == 1:                
+        elif len(ListSeries) > 1 or (AlwaysChooseSerie and len(ListSeries) >= 1) :
+            if AllowUserChoice or nBooksIn == 1:
                 lUnique = False
-                for i in range(len(ListSeries)):                        
-#modif kiwi
+                for i in range(len(ListSeries)):
                     if remove_accents(ListSeries[i][1].lower()) == remove_accents(dlgName.lower().strip()):
                         lUnique = True
                         nItem = i
@@ -652,33 +634,32 @@ def SetSerieId(book, serie, num, nBooksIn):
                     if DBGONOFF:print Trans(111) + (ListSeries[nItem][1])
                     log_BD("** [" + serie + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com" + serieUrl + ")", Trans(25), 1)
                     log_BD(Trans(111), "[" + ListSeries[nItem][1] + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com\\" + ListSeries[nItem][0] + ")", 1)
-                    RenameSeries = ListSeries[nItem][1]                    
+                    RenameSeries = ListSeries[nItem][1]
                     return ListSeries[nItem][0]
                 # Pick a series
                 NewLink = ''
-                NewSeries = ''                                    
+                NewSeries = ''
                 a = ListSeries
                 pickAseries = SeriesForm(serie, ListSeries, FormType.SERIE)
                 result = pickAseries.ShowDialog()
-            
+
                 if result == DialogResult.Cancel:
-                    if DBGONOFF:print Trans(24) + checkWebChar(serie) + "]"                        
+                    if DBGONOFF:print Trans(24) + checkWebChar(serie) + "]"
                     log_BD("** [" + serie + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com" + serieUrl + ")", Trans(25), 1)
-                    return    ''                    
+                    return ''
                 else:
-                    if DBGONOFF:print Trans(24) + checkWebChar(serie) + "]"                        
-                    if DBGONOFF:print Trans(111) + (NewSeries)                        
+                    if DBGONOFF:print Trans(24) + checkWebChar(serie) + "]"
+                    if DBGONOFF:print Trans(111) + (NewSeries)
                     log_BD("** [" + serie + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com" + serieUrl + ")", Trans(25), 1)
                     log_BD(Trans(111), "[" + NewSeries + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com\\" + NewLink + ")", 1)
-                    RenameSeries = NewSeries                        
-#modif kiwi
-                    PickSeries    = RenameSeries
-                    PickSeriesLink = NewLink                        
+                    RenameSeries = NewSeries
+                    PickSeries = RenameSeries
+                    PickSeriesLink = NewLink
                     return NewLink
             else:
-                if DBGONOFF:print Trans(142) + checkWebChar(serie) + "]"                        
+                if DBGONOFF:print Trans(142) + checkWebChar(serie) + "]"
                 log_BD("** [" + serie + "] " + num + if_else(dlgAltNumber == '', '', ' AltNo. ' + dlgAltNumber) + " - " + titlize(book.Title) + " (www.bedetheque.com" + serieUrl + ")", Trans(25), 1)
-                return    ''                            
+                return ''
 
     except:
 
@@ -716,7 +697,7 @@ def SetAlbumInformation(book, serieUrl, serie, num):
     if bStopit:
         if DBGONOFF:print "Cancelled from SetAlbumInformation"
         return False
-    
+
     if albumUrl and not '/revue-' in serieUrl:
         if DBGONOFF:print Trans(26), albumUrl
         if not parseAlbumInfo(book, albumUrl, num):
@@ -739,23 +720,19 @@ def parseSerieInfo(book, serieUrl, lDirect):
     if DBGONOFF:print "=" * 60
     if DBGONOFF:print "parseSerieInfo", "a)", serieUrl, "b)", lDirect
     if DBGONOFF:print "=" * 60
-    
-    #SERIE_HEADER = re.compile(SERIE_HEADER_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
+
     SERIE_QSERIE = re.compile(SERIE_QSERIE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
     
     SkipAlbum = False
     albumURL = ''
     
-    #LongSerie= re.sub(u'^_10000\.html','\_\_10000.html',serieUrl.lower())
-
     if bStopit:
         if DBGONOFF:print "Cancelled from parseSerieInfo Start"
         return False
-        
+
     try:
         request = _read_url(serieUrl, lDirect)
-        #request = _read_url(LongSerie, lDirect)
-    except:        
+    except:
         cError = debuglog()
         log_BD("   " + serieUrl + " " + Trans(43), "", 1)
         return False
@@ -768,7 +745,7 @@ def parseSerieInfo(book, serieUrl, lDirect):
         i = 1
         ListAlbum = list()
         REVUE_LIST_ALL = re.findall(r"<option\svalue=\"(https://www\.bedetheque\.com/revue-[^>]+?)\">(.+?)</option>", request, re.IGNORECASE | re.DOTALL | re.MULTILINE)
-        
+
         #When only 1 page
         if not REVUE_LIST_ALL or len(REVUE_LIST_ALL) == 0:
             REVUE_LIST_ALL_ALT = re.findall(r'<a name="(.+?)">.+?class="titre".{1,100}?#(.+?)\..+?', request, re.IGNORECASE | re.DOTALL | re.MULTILINE)
@@ -780,7 +757,7 @@ def parseSerieInfo(book, serieUrl, lDirect):
             for albumPick in REVUE_LIST_ALL:
                 ListAlbum.append([albumPick[0], "Num: " + albumPick[1].strip(), str(i).zfill(5)])
                 i = i + 1
-       
+
         matchedAlbum = next((x for x in ListAlbum if x[1] == "Num: " + dlgNumber), None) #find num in list
         if matchedAlbum is not None and not lDirect:
             albumURL = matchedAlbum[0]
@@ -788,13 +765,13 @@ def parseSerieInfo(book, serieUrl, lDirect):
             albumURL = serieUrl
         else:
             albumURL = AlbumChooser(ListAlbum)
-            
-        if not albumURL:  
+
+        if not albumURL:
             return ""
 
         request = _read_url(albumURL, False)
         
-        ID = albumURL.split('#')[1] if '#' in albumURL else '' 
+        ID = albumURL.split('#')[1] if '#' in albumURL else ''
         if ID:
             REVUE_HEADER = re.compile(REVUE_HEADER_PATTERN_ALT % ID, re.IGNORECASE | re.MULTILINE | re.DOTALL)   
         else:
@@ -816,26 +793,22 @@ def parseSerieInfo(book, serieUrl, lDirect):
                 if CBSeries:
                     book.Series = titlize(RenameSeries)
 
-            #Series if Quickscrape and empty name
-            qserie = ""
-            if lDirect and not book.Series:
+            #Series if Quickscrape
+            if lDirect and CBSeries:
                 nameRegex = SERIE_QSERIE.search(Entete)
                 if nameRegex:
                     qserie = checkWebChar(nameRegex.group(1).strip())
-                    #qserie = checkWebChar(nameRegex.group(1).decode('utf-8'))        
-                    if CBSeries:    
-                        book.Series = titlize(qserie)
-                        if DBGONOFF:print Trans(9), qserie
+                    book.Series = titlize(qserie)
+                    if DBGONOFF:print Trans(9), qserie
                 else:
                     albumURL = False
-                    return
-    
+                    return ""
+
             #genre
             if CBGenre:
                 nameRegex = SERIE_GENRE.search(Entete)
                 if nameRegex:
                     genre = checkWebChar(nameRegex.group(1).strip())
-                    #genre = checkWebChar(nameRegex.group('genre').decode('utf-8'))
                 else:
                     genre = ""
                 if genre != "":
@@ -846,21 +819,20 @@ def parseSerieInfo(book, serieUrl, lDirect):
                 elif genre == "" and '/revue-' in serieUrl:
                     book.Genre = "Revue"
                 if DBGONOFF:print Trans(51), book.Genre
-    
+
             #Resume
-            if CBSynopsys:                                
+            if CBSynopsys:
                 nameRegex = SERIE_RESUME.search(checkWebChar(Entete.replace("\r\n","")), 0)
                 if nameRegex:
                     resume = strip_tags(nameRegex.group(1)).strip()
-                    #resume = strip_tags(nameRegex.group('resume')).decode('utf-8').strip()
                 else:
                     resume = ""
-                
+
                 resume = re.sub(r'Tout sur la série.*?:\s?', "", resume, re.IGNORECASE)
                 Serie_Resume = (checkWebChar(resume)).strip()
                 cResume = if_else(resume, Trans(52), Trans(53))
                 if DBGONOFF:print cResume
-    
+
             #fini
             if CBStatus:
                 SerieState = ""
@@ -870,7 +842,7 @@ def parseSerieInfo(book, serieUrl, lDirect):
                     log_BD(fin, Trans(25), 1)
                 else:
                     fin = ""
-    
+
                 if ("finie" in fin) or (dlgNumber.lower() == "one shot"):
                     book.SeriesComplete = YesNo.Yes
                     SerieState = Trans(54)
@@ -885,9 +857,9 @@ def parseSerieInfo(book, serieUrl, lDirect):
                 else:
                     book.SeriesComplete = YesNo.Unknown
                     SerieState = Trans(56)
-    
+
                 if DBGONOFF:print Trans(57) + SerieState + if_else(dlgNumber.lower() == "one shot", " (One Shot)", "")
-    
+
             # Language
             if CBLanguage:
                 nameRegex = SERIE_LANGUE.search(Entete)
@@ -896,12 +868,12 @@ def parseSerieInfo(book, serieUrl, lDirect):
                     langue = nameRegex.group(1).strip()
                     if DBGONOFF:print Trans(36), langue[:2]
                     book.LanguageISO = dLang[langue[:2]]
-                
+
             #Default Values
             if not CBDefault:
                 book.EnableProposed = YesNo.No
                 if DBGONOFF:print Trans(136), "No"
-    
+
             SerieInfoRegex = SERIE_HEADER2.search(request)
             if SerieInfoRegex:
                 Entete2 = SerieInfoRegex.group(1)
@@ -922,7 +894,10 @@ def parseSerieInfo(book, serieUrl, lDirect):
 
                     count = 0
                     cCountText = ""
-                    if not COUNTOF:
+                    if COUNTFINIE and book.SeriesComplete == YesNo.No:
+                        book.Count = -1
+                        cCountText = "---"
+                    elif not COUNTOF:
                         nameRegex = SERIE_COUNT.search(Entete2)
                         if nameRegex and AlbumNumNum:
                             count = checkWebChar(nameRegex.group(1))
@@ -931,9 +906,6 @@ def parseSerieInfo(book, serieUrl, lDirect):
                         else:
                             book.Count = -1
                             cCountText = "---"
-                    elif COUNTFINIE and book.SeriesComplete == YesNo.No:
-                        book.Count = -1
-                        cCountText = "---"
                     else:
                         nameRegex = SERIE_COUNT_REAL.search(request)
                         if nameRegex:
@@ -985,20 +957,20 @@ ListAlbum elements:
     2nd is the title
 """
 def AlbumChooser(ListAlbum):
-    
+
     global NewLink
-    
+
     albumURL = ""
     if DBGONOFF:print "Nbr. d'item dans la Liste Album est de: " + str(len(ListAlbum))
     if len(ListAlbum) > 1:
-        if (CBStop == True or CBStop == "2"):
+        if AllowUserChoice:
             NewLink = ""
-            NewSeries = ""                                    
+            NewSeries = ""
             pickAnAlbum = SeriesForm(dlgNumber, ListAlbum, FormType.ALBUM)
             result = pickAnAlbum.ShowDialog()
                 
             if result == DialogResult.Cancel:
-                if CBStop == "2" and TimerExpired:
+                if TIMEPOPUP != "0" and TimerExpired:
                     albumURL = ListAlbum[0][0]
                     if DBGONOFF:print "---> Le temps est expiré, choix du 1er item"
                 else:
@@ -1013,7 +985,7 @@ def AlbumChooser(ListAlbum):
     elif len(ListAlbum) == 1:
         albumURL = ListAlbum[0][0]
         if DBGONOFF:print "---> Seulement 1 item dans la liste"    
-        
+
     return albumURL
 
 def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
@@ -1025,7 +997,7 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
         
         Entete = SerieInfoRegex.group(1)
         Numero = SerieInfoRegex.group(3) if not Numero else Numero
-        
+
         if RenameSeries:
             if CBSeries:
                 book.Series = titlize(RenameSeries)
@@ -1039,25 +1011,25 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
                 if DBGONOFF:print Trans(115), book.Number
             except:
                 book.Number = ""
-            
+
         if serie:
-            try:                  
+            try:
                 if serie.group(1):
                     if CBSeries:
                         book.Series = titlize(serie.group(1))
                         if DBGONOFF:print Trans(9), titlize(book.Series)
             except:
                 pass
-        
+
         #Title
         if CBTitle:
             nameRegex = re.search(r'<h3 class="titre".+?</span>(.+?)</h3>', Entete, re.IGNORECASE | re.DOTALL | re.MULTILINE)
             if nameRegex: 
                 book.Title = titlize(nameRegex.group(1).strip())
             if DBGONOFF:print Trans(29), book.Title
-                
+
         #genre
-        if CBGenre:        
+        if CBGenre:
             book.Genre = "Revue"
             if DBGONOFF:print Trans(51), book.Genre
 
@@ -1065,14 +1037,13 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
         if CBSynopsys:
             nameRegex = REVUE_RESUME.search(Entete)
             if nameRegex:
-                #resume = strip_tags(nameRegex.group(1)).decode('utf-8').strip()
                 resume = strip_tags(nameRegex.group(1)).strip()
             else:
                 resume = ""
             book.Summary = (checkWebChar(resume)).strip()
             cResume = if_else(resume, Trans(52), Trans(53))
             if DBGONOFF:print cResume
-        
+
         #Notes-Rating
         if CBRating:
             nameRegex = SERIE_NOTE.search(Entete)
@@ -1083,7 +1054,7 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
 
             book.CommunityRating = float(note)
             if DBGONOFF:print Trans(58) + str(float(note))
-    
+
         #Couverture
         # Cover Image only for fileless
         if CBCover and not book.FilePath:
@@ -1094,10 +1065,9 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
             retval = Image.FromStream(response_stream)
             ComicRack.App.SetCustomBookThumbnail(book, retval)
             if DBGONOFF:print Trans(105), CoverImg
-    
+
         #Parution
         if CBPrinted:
-            #REVUE_DEPOT = re.compile(REVUE_DEPOT_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
             nameRegex = REVUE_DEPOT.search(Entete, 0)
             if nameRegex:
                 if nameRegex.group(1) != '-':
@@ -1110,23 +1080,20 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
             else:
                 book.Month = -1
                 book.Year = -1
-    
+
         #Editeur
         if CBEditor:
-            #ALBUM_EDITEUR = re.compile(ALBUM_EDITEUR_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
             nameRegex = ALBUM_EDITEUR.search(Entete, 0)
             if nameRegex:
                 editeur = parseNames(nameRegex.group(1))
-                #editeur = parseNames(nameRegex.group(1).decode('utf-8'))
                 book.Publisher = editeur
             else:
                 book.Publisher = ""
                     
             if DBGONOFF:print Trans(35), book.Publisher
-        
-        # Planches            
+
+        # Planches
         if not book.FilePath:
-            #REVUE_PLANCHES = re.compile(REVUE_PLANCHES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
             nameRegex = REVUE_PLANCHES.search(Entete, 0)
             if nameRegex:
                 book.PageCount = int(nameRegex.group(1).strip())
@@ -1134,7 +1101,6 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
 
         #Periodicité
         if CBFormat:
-            #REVUE_PERIOD = re.compile(REVUE_PERIOD_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
             nameRegex = REVUE_PERIOD.search(Entete, 0)
             if nameRegex:
                 book.Format = nameRegex.group(1).strip()
@@ -1148,10 +1114,10 @@ def parseRevueInfo(book, SerieInfoRegex, serieUrl, Numero = "", serie = ""):
         if CBWeb == True and not CBRescrape:
             book.Web = serieUrl
             if DBGONOFF:print Trans(123), book.Web
-                        
+
         if CBNotes:
             write_book_notes(book)
-                
+
         return True
 
     except:
@@ -1164,43 +1130,43 @@ class AlbumInfo:
         self.N = n
         self.A = a
         self.Title = title
-        self.Info = info    
+        self.Info = info
         self.URL = url
 
 def parseAlbumInfo(book, pageUrl, num, lDirect = False):
 
     global CBelid, NewLink, NewSeries
-    
+
     if DBGONOFF:print "=" * 60
     if DBGONOFF:print "parseAlbumInfo", "a)", pageUrl, "b)", num , "c)", lDirect
     if DBGONOFF:print "=" * 60
-    
+
     AlbumBDThequeNum = ""
-    
+
     if bStopit:
         if DBGONOFF:print "Cancelled from parseAlbumInfo Start"
         return False
 
-    albumUrl = _read_url(pageUrl, False)    
-    
+    albumUrl = _read_url(pageUrl, False)
+
     if bStopit:
         if DBGONOFF:print "Cancelled from parseAlbumInfo after _read_url return"
         return False
-    
+
     #identify the album n. in BDTHQ
     cBDNum = False
-    cBDNumS = re.search(r'\-(\d+).html', pageUrl)
+    cBDNumS = re.search(r'-(\d+).html', pageUrl)
     if cBDNumS:
         cBDNum = cBDNumS.group(1)
-        if cBDNum:                
+        if cBDNum:
             AlbumBDThequeNum = cBDNum
     elif "serie-" in pageUrl:
-        ID_ALBUM_PATT = re.search(r'serie.*?\.html\#(\d+)$', pageUrl)        
-        if ID_ALBUM_PATT:            
-            ID_ALBUM = ID_ALBUM_PATT.group(1)        
+        ID_ALBUM_PATT = re.search(r'serie.*?\.html\#(\d+)$', pageUrl)
+        if ID_ALBUM_PATT:
+            ID_ALBUM = ID_ALBUM_PATT.group(1)
             AlbumBDThequeNum = ID_ALBUM
-                
-    else:        
+
+    else:
         # Album N. est Numerique
         if dlgNumber or dlgAltNumber:
             ALBUM_BDTHEQUE_NUM_PATTERN = r'tails\">%s<span\sclass=\"numa">%s</span>.*?<a name=\"(.*?)\"'
@@ -1220,20 +1186,19 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                     # Album not found
                     nameRegex = ""
                     return False
-        
-        # Album N. in Lettres                
-        else:            
-            #ALBUM_BDTHEQUE_NOTNUM = re.compile(ALBUM_BDTHEQUE_NOTNUM_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
+
+        # Album N. in Lettres
+        else:
             nameRegex = ALBUM_BDTHEQUE_NOTNUM.search(albumUrl)
             if nameRegex:
                 AlbumBDThequeNum = nameRegex.group(1)
-                    
+
             else:
-            
+
                 nameRegex = ""
                 return False
-    
-    try:        
+
+    try:
         i = 0
         ListAlbum = list()
         pickedVar = ""
@@ -1253,33 +1218,33 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
             url = pageUrl + "#reed" if i == 0 else pageUrl + "#" + albumPick.group(6).strip()
             albumInfo = AlbumInfo(t, a, title, nfo, couv, url)
             if DBGONOFF:print "Tome)", t, "Alt)", a, "Title)", title
-            
+
             ListAlbum.append([a, albumInfo, str(i).zfill(3)])
             i = i + 1
-        
+
         if len(ListAlbum) == 1:
             pickedVar = ListAlbum[0][1]
-            if DBGONOFF:print "---> Seulement 1 item dans la liste"    
-        elif len(ListAlbum) > 1:            
+            if DBGONOFF:print "---> Seulement 1 item dans la liste"
+        elif len(ListAlbum) > 1:
             for f in ListAlbum:
                 #iterate over editions and if AltNumber matches auto choose it.
                 if dlgAltNumber != "" and f[1].A == dlgAltNumber:
                     pickedVar = f[1]
                     picked = True
                     break
-            
+
             #set that the already picked edition from above wasn't chosen when the option to choose is enabled in config, so we will have the chance to pick it later.
             if PopUpEditionForm:
                 picked = False
-            
+
             #show the choose editions form when the option is enabled and the edition wasn't already chosen earlier based on the AltNumber from the book.
             #NewLink (first element from the ListAlbum, in this case the var "a") & NewSeries (object AlbumInfo) are global value that are set when ok is clicked on the form
-            if PopUpEditionForm and (CBStop == True or CBStop == "2") and not picked:
+            if PopUpEditionForm and AllowUserChoice and not picked:
                 NewLink = ""
-                NewSeries = ""    
+                NewSeries = ""
                 pickAvar = SeriesForm(num, ListAlbum, FormType.EDITION)
                 result = pickAvar.ShowDialog()
-                
+
                 if result == DialogResult.Cancel:
                     pickedVar = ListAlbum[0][1]
                     if DBGONOFF:print "---> Cancel appuyer, on choisi le premier"
@@ -1289,11 +1254,11 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
             elif not picked:
                 pickedVar = ListAlbum[0][1]
                 if DBGONOFF:print "---> Choix du 1er item"
-                
+
         if pickedVar :
             info = pickedVar.Info
             if DBGONOFF:print "Choisi #Alt: " + pickedVar.A + " // Titre: " + pickedVar.Title
-            
+
         if info :
             if RenameSeries:
                 if CBSeries:
@@ -1304,17 +1269,18 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
 
             if Shadow2:
                 book.Number = dlgNumber
-            
+
             #web
-            if CBWeb == True and not CBRescrape:            
-                book.Web = pickedVar.URL.replace("#reed", "")
-                if DBGONOFF:print Trans(123), book.Web
-            elif CBWeb == "2" and not CBRescrape:
-                cBelid = re.search(r'\-(\d+).html', pageUrl)
-                if cBelid:            
-                    book.Web = 'www.bedetheque.com/BD--' + cBelid.group(1) + '.html'
+            if CBWeb == True and not CBRescrape:
+                if not ShortWebLink:
+                    book.Web = pickedVar.URL.replace("#reed", "")
                     if DBGONOFF:print Trans(123), book.Web
-            
+                else:
+                    cBelid = re.search(r'-(\d+).html', pageUrl)
+                    if cBelid:
+                        book.Web = 'www.bedetheque.com/BD--' + cBelid.group(1) + '.html'
+                        if DBGONOFF:print Trans(123), book.Web
+
             qnum = pickedVar.N#is equal to t always, but keep it in case of needed modification
             anum = pickedVar.A
             book.Number = anum if not qnum and anum else qnum#set number to Alt if no number and an Alt Exists
@@ -1324,7 +1290,7 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                 if isPositiveInt(book.AlternateNumber): book.AlternateNumber = str(book.AlternateNumber).zfill(int(PadNumber))
             if DBGONOFF:print "Num: ", book.Number
             if DBGONOFF:print "Alt: ", book.AlternateNumber
-        
+
             series = book.Series
             nameRegex = re.search('bandeau-info.+?<h1>.+?>([^"]+?)[<>]', albumUrl, re.IGNORECASE | re.DOTALL | re.MULTILINE)# Les 5 Terres Album et Serie, Comme avant
             nameRegex2 = re.search("<label>S.rie : </label>(.+?)</li>", albumUrl, re.IGNORECASE | re.DOTALL | re.MULTILINE)# 5 Terres (Les) sur Album seulement
@@ -1332,33 +1298,33 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                 seriesFormat = checkWebChar(nameRegex2.group(1).strip())
                 series = checkWebChar(nameRegex.group(1).strip())
                 if DBGONOFF:  print Trans(9) + series + ' // Formaté: ' + seriesFormat
-                
+
             if CBTitle:
                 NewTitle = ""
                 try:
                     NewTitle = titlize(pickedVar.Title)
                 except:
                     NewTitle = pickedVar.Title
-                
+
                 if NewTitle.lower() == series.lower():
                     NewTitle = ""
-                
+
                 book.Title = NewTitle
                 if DBGONOFF:print Trans(29), book.Title
-                                    
+
             if TBTags == "DEL":
                 book.Tags = ""
             elif TBTags != "":
                 book.Tags = TBTags
-            
+
             if CBWriter:
                 nameRegex = ALBUM_SCENAR_MULTI_AUTHOR.search(info, 0)
                 if nameRegex:
                     scenaristes = ""
-                    thisscen = ""                    
+                    thisscen = ""
                     for scenar_multi in ALBUM_SCENAR_MULTI_AUTHOR_NAMES.finditer(nameRegex.group(1)):
                         thisscen = parseNames(scenar_multi.group(1).strip())
-                        if thisscen not in scenaristes:    
+                        if thisscen not in scenaristes:
                             scenaristes = scenaristes + thisscen + ", "
 
                     thisscen = ""
@@ -1366,13 +1332,13 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                         thisscen = parseNames(scenar_multi.group(1).strip())
                         if thisscen not in scenaristes:
                             scenaristes = scenaristes + thisscen + ", "
-            
+
                     book.Writer = scenaristes[:-2]
 
                 else:
 
                     nameRegex = ALBUM_SCENAR.search(info, 0)
-                    if nameRegex:                    
+                    if nameRegex:
                         scenaristes = nameRegex.group(1).strip()
                         book.Writer = parseNames(scenaristes)
                         log_BD(parseNames(scenaristes),"",1)
@@ -1380,14 +1346,14 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                     else:
                         book.Writer = ""
                 if DBGONOFF:print Trans(30), book.Writer
-            
+
             if CBPenciller:
                 nameRegex = ALBUM_DESSIN_MULTI_AUTHOR.search(info, 0)
                 if nameRegex:
                     dessinateurs = ""
-                    for dessin_multi in ALBUM_DESSIN_MULTI_AUTHOR_NAMES.finditer(nameRegex.group(1)):        
+                    for dessin_multi in ALBUM_DESSIN_MULTI_AUTHOR_NAMES.finditer(nameRegex.group(1)):
                         dessinateurs = dessinateurs + parseNames(dessin_multi.group(1).strip()) + ", "
-                            
+
                     book.Penciller = dessinateurs[:-2]
 
                 else:
@@ -1398,17 +1364,17 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
 
                     else:
                         book.Penciller = ""
-                    
+
                 if DBGONOFF:print Trans(31), book.Penciller
-            
+
             if CBColorist:
                 cColorNote = ""
                 nameRegex = ALBUM_COLOR_MULTI_AUTHOR.search(info, 0)
-                cColorist = ""                
-                if nameRegex:                    
+                cColorist = ""
+                if nameRegex:
                     for color_multi in ALBUM_COLOR_MULTI_AUTHOR_NAMES.finditer(nameRegex.group(1)):
                         cColorist = cColorist + parseNames(color_multi.group(1).strip()) + ", "
-                            
+
                     book.Colorist = cColorist[:-2]
                     cColorist = cColorist[:-2]
 
@@ -1424,34 +1390,34 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                             book.Colorist = cColorist
                     else:
                         book.Colorist = ""
-                        
+
                 if DBGONOFF:print Trans(33), cColorist , cColorNote
-            
+
             if CBCouverture:
                 nameRegex = ALBUM_COUVERT_MULTI_AUTHOR.search(info, 0)
-                cCoverNote = ""    
-                if nameRegex:                        
-                    for cover_multi in ALBUM_COUVERT_MULTI_AUTHOR_NAMES.finditer(nameRegex.group(1)):                
+                cCoverNote = ""
+                if nameRegex:
+                    for cover_multi in ALBUM_COUVERT_MULTI_AUTHOR_NAMES.finditer(nameRegex.group(1)):
                         cCoverNote = cCoverNote + parseNames(cover_multi.group(1).strip()) + ", "
-                            
+
                     book.CoverArtist = cCoverNote[:-2]
-                    cCoverNote = ""                        
+                    cCoverNote = ""
 
                 else:
-                    nameRegex = ALBUM_COUVERT.search(info, 0)                        
-                    if nameRegex:                    
+                    nameRegex = ALBUM_COUVERT.search(info, 0)
+                    if nameRegex:
                         couvertures = nameRegex.group(1)
                         cCouvertures = parseNames(couvertures)
                         if re.search("<.*?>", cCouvertures):
                             book.CoverArtist = ""
                             cCoverNote = Trans(32)
                         else:
-                            book.CoverArtist = cCouvertures                            
+                            book.CoverArtist = cCouvertures
                     else:
                         book.CoverArtist = ""
-                        
+
                 if DBGONOFF:print Trans(120), book.CoverArtist , cCoverNote
-            
+
             if CBPrinted:
                 nameRegex = ALBUM_DEPOT.search(info, 0)
                 if nameRegex:
@@ -1464,19 +1430,18 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                         book.Year = -1
                 else:
                     book.Month = -1
-                    book.Year = -1    
-            
+                    book.Year = -1
+
             if CBEditor:
                 nameRegex = ALBUM_EDITEUR.search(info, 0)
                 if nameRegex:
-                    #editeur = parseNames(nameRegex.group(1).decode('utf-8'))
                     editeur = parseNames(nameRegex.group(1)).strip()
                     book.Publisher = editeur
                 else:
                     book.Publisher = ""
-                    
+
                 if DBGONOFF:print Trans(35), book.Publisher
-            
+
             if CBISBN:
                 nameRegex = ALBUM_ISBN.search(info, 0)
                 if nameRegex:
@@ -1487,109 +1452,98 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                         book.ISBN = ""
                 else:
                     book.ISBN = ""
-                    
+
                 if DBGONOFF:print "ISBN: ", book.ISBN
-            
+
             # Lettrage is optional => So, there is a specific research
             if CBLetterer:
-                #ALBUM_LETTRAGE = re.compile(ALBUM_LETTRAGE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
-                nameRegex = ALBUM_LETTRAGE.search(info, 0)                                
+                nameRegex = ALBUM_LETTRAGE.search(info, 0)
                 if nameRegex:
                     letterer = nameRegex.group(1).strip()
-                    #letterer = nameRegex.group(1).decode('utf-8')
                     book.Letterer = parseNames(letterer)
                 else:
                     book.Letterer = ""
-                        
+
                 if DBGONOFF:print Trans(38), book.Letterer 
             
             # Album evaluation is optional => So, there is a specific research
             if CBRating:
-                #ALBUM_EVAL = re.compile(ALBUM_EVAL_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
-                nameRegex = ALBUM_EVAL.search(albumUrl, 0)                                                        
+                nameRegex = ALBUM_EVAL.search(albumUrl, 0)
                 if nameRegex:
                     evaluation = nameRegex.group(1)
                     book.CommunityRating = float(evaluation)
                     if DBGONOFF:print Trans(39) + str(float(evaluation))
-            
+
             # Achevè imp. is optional => So, there is a specific research
             if CBPrinted:
-                #ALBUM_ACHEVE = re.compile(ALBUM_ACHEVE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)                                                                       
                 nameRegex = ALBUM_ACHEVE.search(info, 0)
                 if nameRegex and book.Month < 1:
                     book.Month = int(nameRegex.group('month'))
                     book.Year = int(nameRegex.group('year'))
                     if DBGONOFF:print Trans(40), str(book.Month) + "/" + str(book.Year)
-            
+
             # Collection is optional => So, there is a specific research
             if CBImprint:
-                #ALBUM_COLLECTION = re.compile(ALBUM_COLLECTION_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
                 nameRegex = ALBUM_COLLECTION.search(albumUrl, 0)
                 nameRegex2 = ALBUM_COLLECTION.search(info, 0)
                 if nameRegex or nameRegex2:
                     if nameRegex2:
                         nameRegex = nameRegex2
-                        
+
                     collection = nameRegex.group(1)
-                    #collection = nameRegex.group(1).decode('utf-8')
                     book.Imprint = checkWebChar(collection)
                 else:
                     book.Imprint = ""
-                    
+
                 if DBGONOFF:print Trans(41), book.Imprint
-            
+
             # Format is optional => So, there is a specific research
             if CBFormat:
-                #ALBUM_TAILLE = re.compile(ALBUM_TAILLE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
                 nameRegex = ALBUM_TAILLE.search(info, 0)
                 if nameRegex:
                     taille = nameRegex.group(1)
                     book.Format = taille
                 else:
                     book.Format = "" 
-                    
+
                 if DBGONOFF:print Trans(42), book.Format
-            
+
             # Album summary is optional => So, there is a specific research
             if CBSynopsys:
-                #ALBUM_RESUME = re.compile(ALBUM_RESUME_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
                 summary = ""
-                nameRegex = ALBUM_RESUME.search(albumUrl, 0)                                                                        
-                if nameRegex:                    
-                    resume = strip_tags(nameRegex.group(1)).strip()                        
+                nameRegex = ALBUM_RESUME.search(albumUrl, 0)
+                if nameRegex:
+                    resume = strip_tags(nameRegex.group(1)).strip()
                     resume = re.sub(r'Tout sur la série.*?:\s?', "", resume, re.IGNORECASE)
-                    #resume = strip_tags(nameRegex.group(1)).decode('utf-8').strip()
                     PrintSerieResume = True if SerieResumeEverywhere else book.Number == '1'
                     if Serie_Resume and PrintSerieResume and remove_accents(Serie_Resume) != remove_accents(resume):
                         summary = Serie_Resume + if_else(resume, chr(10) + chr(10) + if_else(book.Title, '>' + book.Title + '< ' + chr(10), "") + resume, "")                    
                     elif resume:
                         summary = if_else(book.Title, '>' + book.Title + '< ' + chr(10), "") + resume
 
-                        if DBGONOFF:print Trans(100)                        
+                        if DBGONOFF:print Trans(100)
                 else:
                     if DBGONOFF:print Trans(101)
 
-            # Info edition            
-                #ALBUM_INFOEDITION = re.compile(ALBUM_INFOEDITION_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
-                nameRegex = ALBUM_INFOEDITION.search(info, 0)                                                        
-                if nameRegex:                                        
-                    if nameRegex.group(1) !=" &nbsp;":                        
+                # Info edition
+                nameRegex = ALBUM_INFOEDITION.search(info, 0)
+                if nameRegex:
+                    if nameRegex.group(1) !=" &nbsp;":
                         infoedition = strip_tags(nameRegex.group(1)).strip()
-                        #infoedition = strip_tags(nameRegex.group(1)).decode('utf-8').strip()
                         if infoedition:
                             summary = if_else(summary != "",summary + chr(10) + chr(10) + Trans(118) + infoedition,Trans(118) + infoedition)
-                        if DBGONOFF:print Trans(118) + Trans(119)        
-                        
+                        if DBGONOFF:print Trans(118) + Trans(119)
+
                 #Send Summary to book
                 if summary:
                     book.Summary = summary
-                        
+
             # series
-            if CBSeries:                                                    
+            if CBSeries:
                 formatted = titlize(seriesFormat, False) if seriesFormat else titlize(series, True)
                 book.Series = formatted if FORMATARTICLES else titlize(series, False)
                 if DBGONOFF:print Trans(9), book.Series
-            
+
             # Cover Image only for fileless
             if CBCover and not book.FilePath:
                 if pickedVar.Couv:
@@ -1600,11 +1554,11 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
                     retval = Image.FromStream(response_stream)
                     ComicRack.App.SetCustomBookThumbnail(book, retval)
                     if DBGONOFF:print Trans(105), CoverImg    
-            
+
             #When QS, no language is set. This is a Temp solution, because there could be other language, but we must go through the series page to check
             if CBLanguage and lDirect and not book.LanguageISO:
                 book.LanguageISO = "fr"
-                    
+
             # Planches
             if not book.FilePath:
                 #ALBUM_PLANCHES = re.compile(ALBUM_PLANCHES_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)    
@@ -1625,12 +1579,11 @@ def parseAlbumInfo(book, pageUrl, num, lDirect = False):
         cError = debuglog()
         log_BD("   " + pageUrl + " " + Trans(43), "", 1)
         return False
-        
+
     return True
 
 def parseNames(extractedNames):
-    
-    #RAW_STR = re.compile(RAW_STR_PATTERN)
+
     newstr = RAW_STR.sub('=', extractedNames)
 
     splitted = newstr.split('=')
@@ -1662,8 +1615,6 @@ def _read_url(url, bSingle):
         if DBGONOFF:print "Cancelled from _read_url Start"
         return page
 
-    #headers = { 'User-Agent' : 'Mozilla/5.0'}
-    ##headers = { 'User-Agent' : 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)', 'Accept-Encoding':'gzip, deflate','Accept':'text/html, application/xhtml+xml, */*','Accept-Language':'en-GB,it-IT;q=0.8,it;q=0.6,en-US;q=0.4,en;q=0.2'}
     if not bSingle and re.search("https://www.bedetheque.com/", url, re.IGNORECASE):
         bSingle = True
 
@@ -1671,25 +1622,11 @@ def _read_url(url, bSingle):
         requestUri = quote(url, safe = "%/:=&~#+$!,?;'@()*[]")
     else:
         requestUri = quote("https://www.bedetheque.com/" + url, safe = "%/:=&~#+$!,?;'@()*[]")
-            
-    #try:        
-    #    req = Request (requestUri, None, headers)
-    #    page = urlopen(req).read()
-    #    Application.DoEvents()
-
-    #except URLError, e:
-    #    if DBGONOFF:print Trans(60)
-    #    if DBGONOFF:print Trans(61), e
-    #    cError = debuglog()
-    #    log_BD("   [" + dlgName + "] " + dlgNumber + " Alt.No " + dlgAltNumber + " -> " , cError, 1)
-    #    Result = MessageBox.Show(ComicRack.MainWindow, Trans(98) + cError ,Trans(97), MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
-
-    #return page
 
     try:
         System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12
-        Req = System.Net.HttpWebRequest.Create(requestUri)        
-        Req.CookieContainer = CookieContainer        
+        Req = System.Net.HttpWebRequest.Create(requestUri)
+        Req.CookieContainer = CookieContainer
         #Req.CookieContainer.Add(System.Uri(requestUri), Cookie("__utma", "164207276.656597940.1352121294.1352232667.1352393821.4"))
         #Req.CookieContainer.Add(System.Uri(requestUri), Cookie("__utmb", "164207276.4.10.1352232512"))
         #Req.CookieContainer.Add(System.Uri(requestUri), Cookie("__utmc", "164207276"))
@@ -1699,36 +1636,36 @@ def _read_url(url, bSingle):
         Req.Timeout = 15000
         Req.UserAgent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)'
         #Req.Headers.Add('Accept-Encoding','gzip, deflate')
-        Req.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip        
+        Req.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip
         Req.Headers.Add('X-Powered-By', 'PHP/5.3.17')
         Req.Referer = requestUri
         Req.Accept = 'text/html, application/xhtml+xml, */*'
         Req.Headers.Add('Accept-Language','en-GB,it-IT;q=0.8,it;q=0.6,en-US;q=0.4,en;q=0.2')
-        Req.KeepAlive = True        
+        Req.KeepAlive = True
         webresponse = Req.GetResponse()
-        a = webresponse.Cookies    
+        a = webresponse.Cookies
 
         Application.DoEvents()
         if bStopit:
             if DBGONOFF:print "Cancelled from _read_url End"
             return page
 
-        inStream = webresponse.GetResponseStream()        
+        inStream = webresponse.GetResponseStream()
         encode = System.Text.Encoding.GetEncoding("utf-8")
         ReadStream = System.IO.StreamReader(inStream, encode)
-        #ReadStream.BaseStream.ReadTimeout = 15000        
+        #ReadStream.BaseStream.ReadTimeout = 15000
         page = ReadStream.ReadToEnd()
-            
+
     except URLError, e:
         if DBGONOFF:print Trans(60)
         if DBGONOFF:print Trans(61), e
         cError = debuglog()
         log_BD("   [" + dlgName + "] " + dlgNumber + " Alt.No " + dlgAltNumber + " -> " , cError, 1)
         Result = MessageBox.Show(ComicRack.MainWindow, Trans(98) + cError ,Trans(97), MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
-    
+
     inStream.Close()
     webresponse.Close()
-    
+
     return page
 
 def isnumeric(nNum):
@@ -1762,34 +1699,19 @@ def checkRegExp(strIn):
     strIn = re.sub('&', '&amp;', strIn)
     strIn = re.sub('"', '&quot;', strIn)
     strIn = re.sub('\$', '\\$', strIn)
-    
+
     return strIn
-
-class MLStripper(HTMLParser):
-
-    def __init__(self):
-        self.reset()
-        self.fed = []
-
-    def handle_data(self, d):
-        self.fed.append(d)
-
-    def Set_data(self):
-        return ''.join(self.fed)
 
 def strip_tags(html):
     try:
-        # s = MLStripper()
-        # s.feed(html)
-        # return s.Set_data()
         return re.sub("<[^<>]+?>", "", html, re.IGNORECASE | re.DOTALL | re.MULTILINE)
     except:
         return html
 
-def thread_proc():     
-    
+def thread_proc():
+
     pass
-    
+
     def handle(w, a): 
         pass
 
@@ -1854,11 +1776,11 @@ def isPositiveInt(value):
         return False
 
 def url_fix(s, charset='utf-8'):
-        
+
     if isinstance(s, unicode):
         s = s.encode(charset, 'ignore')
         s = s.replace("/","-")
-        
+
     scheme, netloc, path, qs, anchor = urlparse.urlsplit(s)
     path = quote(path, '/%')
     qs = quote_plus(qs, ':&=')
@@ -1877,7 +1799,7 @@ def log_BD(bdstr, bdstat, lTime):
         cDT = ""
 
     bdlog.write (cDT.encode('utf-8') + bdstr.encode('utf-8') + "   " + bdstat.encode('utf-8') + "\n")
-    
+
     bdlog.close()
 
 def if_else(condition, trueVal, falseVal):
@@ -1886,11 +1808,11 @@ def if_else(condition, trueVal, falseVal):
         return trueVal
     else:
         return falseVal
-        
+
 class ProgressBarDialog(Form):
-    
+
     def __init__(self, nMax):
-       
+
         global bStopit
         bStopit = False
         self.Text = Trans(62)
@@ -1945,7 +1867,7 @@ class ProgressBarDialog(Form):
         self.Controls.Add(self.traitement)
         self.Controls.Add(self.cancel)
         self.Controls.Add(self.cover)
-        
+
         # Adjust DPI scaling in this form
         HighDpiHelper.AdjustControlImagesDpiScale(self)
 
@@ -1957,7 +1879,7 @@ class ProgressBarDialog(Form):
             self.pb.Increment(self.pb.Step)
             percent = int((float(self.pb.Value - self.pb.Minimum) / float(self.pb.Maximum - self.pb.Minimum)) * 100)
             self.Text = Trans(63) + percent.ToString() + "%"
-            
+
         if book:
             cCovImage = (ComicRack.App.GetComicThumbnail(book, 0))
         else:
@@ -1976,29 +1898,29 @@ class ProgressBarDialog(Form):
         if sender.Name.CompareTo(self.cancel.Name) == 0:
             if DBGONOFF:print "Cancel button pressed"
             bStopit = True
-    
+
 def LoadSetting():
 
     global SHOWRENLOG, SHOWDBGLOG, DBGONOFF, DBGLOGMAX, RENLOGMAX, LANGENFR, aWord, ARTICLES, SUBPATT, COUNTOF, COUNTFINIE, TITLEIT, TIMEOUT, TIMEOUTS, TIMEPOPUP, FORMATARTICLES, ONESHOTFORMAT
-    global TBTags, CBCover, CBStatus, CBGenre, CBNotes, CBWeb, CBCount, CBSynopsys, CBImprint, CBLetterer, CBPrinted, CBRating, CBISBN, CBDefault, CBRescrape, CBStop, PopUpEditionForm, PadNumber, SerieResumeEverywhere
-    global CBLanguage, CBEditor, CBFormat, CBColorist, CBPenciller, CBWriter, CBTitle, CBSeries, CBCouverture, AlwaysChooseSerie
+    global TBTags, CBCover, CBStatus, CBGenre, CBNotes, CBWeb, CBCount, CBSynopsys, CBImprint, CBLetterer, CBPrinted, CBRating, CBISBN, CBDefault, CBRescrape, AllowUserChoice, PopUpEditionForm, PadNumber, SerieResumeEverywhere
+    global CBLanguage, CBEditor, CBFormat, CBColorist, CBPenciller, CBWriter, CBTitle, CBSeries, CBCouverture, AlwaysChooseSerie, ShortWebLink
 
     ###############################################################
     # Config read #
 
     path = (__file__[:-len('BedethequeScraper2.py')])
-    
+
     if not File.Exists(path + "\App.Config"):
         fs = File.Create(path + "\App.Config")
         info = System.Text.UTF8Encoding(True).GetBytes('<?xml version="1.0" encoding="UTF-8"?><configuration></configuration>')
         fs.Write(info, 0, info.Length)
         fs.Close()
 
-    try:    
+    try:
         MySettings = AppSettings()
         MySettings.Load(path + "\App.Config")
     except Exception as e:
-        cError = debuglog()        
+        cError = debuglog()
         return False
 
     try:
@@ -2010,7 +1932,7 @@ def LoadSetting():
     except Exception as e:
         SHOWDBGLOG = False
     try:
-        DBGONOFF = ft(MySettings.Get("DBGONOFF"))    
+        DBGONOFF = ft(MySettings.Get("DBGONOFF"))
     except Exception as e:
         DBGONOFF = False
     try:
@@ -2030,71 +1952,75 @@ def LoadSetting():
     except Exception as e:
         TBTags = ""
     try:
-        CBCover = ft(MySettings.Get("CBCover"))    
+        CBCover = ft(MySettings.Get("CBCover"))
     except Exception as e:
         CBCover = True
     try:
-        CBStatus = ft(MySettings.Get("CBStatus"))    
+        CBStatus = ft(MySettings.Get("CBStatus"))
     except Exception as e:
         CBStatus = True
     try:
-        CBGenre = ft(MySettings.Get("CBGenre"))    
+        CBGenre = ft(MySettings.Get("CBGenre"))
     except Exception as e:
         CBGenre = True
     try:
-        CBNotes = ft(MySettings.Get("CBNotes"))    
+        CBNotes = ft(MySettings.Get("CBNotes"))
     except Exception as e:
         CBNotes = True
     try:
-        CBWeb = ft(MySettings.Get("CBWeb"))    
+        CBWeb = ft(MySettings.Get("CBWeb"))
     except Exception as e:
         CBWeb = True
     try:
-        CBCount = ft(MySettings.Get("CBCount"))    
+        ShortWebLink = ft(MySettings.Get("ShortWebLink"))
+    except Exception as e:
+        ShortWebLink = False
+    try:
+        CBCount = ft(MySettings.Get("CBCount"))
     except Exception as e:
         CBCount = True
     try:
-        CBSynopsys = ft(MySettings.Get("CBSynopsys"))    
+        CBSynopsys = ft(MySettings.Get("CBSynopsys"))
     except Exception as e:
         CBSynopsys = True
     try:
-        CBImprint = ft(MySettings.Get("CBImprint"))    
+        CBImprint = ft(MySettings.Get("CBImprint"))
     except Exception as e:
         CBImprint = True
     try:
-        CBLetterer = ft(MySettings.Get("CBLetterer"))    
+        CBLetterer = ft(MySettings.Get("CBLetterer"))
     except Exception as e:
         CBLetterer = True
     try:
-        CBPrinted = ft(MySettings.Get("CBPrinted"))    
+        CBPrinted = ft(MySettings.Get("CBPrinted"))
     except Exception as e:
         CBPrinted = True
     try:
-        CBRating = ft(MySettings.Get("CBRating"))    
+        CBRating = ft(MySettings.Get("CBRating"))
     except Exception as e:
         CBRating = True
     try:
-        CBISBN = ft(MySettings.Get("CBISBN"))    
+        CBISBN = ft(MySettings.Get("CBISBN"))
     except Exception as e:
         CBISBN = True
     try:
-        CBLanguage = ft(MySettings.Get("CBLanguage"))    
+        CBLanguage = ft(MySettings.Get("CBLanguage"))
     except Exception as e:
         CBLanguage = True
     try:
-        CBEditor = ft(MySettings.Get("CBEditor"))    
+        CBEditor = ft(MySettings.Get("CBEditor"))
     except Exception as e:
         CBEditor = True
     try:
-        CBFormat = ft(MySettings.Get("CBFormat"))    
+        CBFormat = ft(MySettings.Get("CBFormat"))
     except Exception as e:
         CBFormat = True
     try:
-        CBColorist = ft(MySettings.Get("CBColorist"))    
+        CBColorist = ft(MySettings.Get("CBColorist"))
     except Exception as e:
         CBColorist = True
     try:
-        CBPenciller = ft(MySettings.Get("CBPenciller"))    
+        CBPenciller = ft(MySettings.Get("CBPenciller"))
     except Exception as e:
         CBPenciller = True
     try:
@@ -2102,11 +2028,11 @@ def LoadSetting():
     except Exception as e:
         CBWriter = True
     try:
-        CBSeries = ft(MySettings.Get("CBSeries")    )
+        CBSeries = ft(MySettings.Get("CBSeries"))
     except Exception as e:
         CBSeries = True
     try:
-        CBTitle = ft(MySettings.Get("CBTitle"))    
+        CBTitle = ft(MySettings.Get("CBTitle"))
     except Exception as e:
         CBTitle = True
     try:
@@ -2118,9 +2044,9 @@ def LoadSetting():
     except Exception as e:
         CBRescrape = False
     try:
-        CBStop = ft(MySettings.Get("CBStop"))
+        AllowUserChoice = ft(MySettings.Get("CBStop"))
     except Exception as e:
-        CBStop = "2"
+        AllowUserChoice = True
     try:
         ARTICLES = MySettings.Get("ARTICLES")
     except Exception as e:
@@ -2128,21 +2054,21 @@ def LoadSetting():
     try:
         SUBPATT = MySettings.Get("SUBPATT")
     except Exception as e:
-        SUBPATT = " - - "       
+        SUBPATT = " - - "
     try:
-        COUNTOF = ft(MySettings.Get("COUNTOF"))    
+        COUNTOF = ft(MySettings.Get("COUNTOF"))
     except Exception as e:
         COUNTOF = True
     try:
-        CBCouverture = ft(MySettings.Get("CBCouverture"))    
+        CBCouverture = ft(MySettings.Get("CBCouverture"))
     except Exception as e:
         CBCouverture = True
     try:
-        COUNTFINIE = ft(MySettings.Get("COUNTFINIE"))    
+        COUNTFINIE = ft(MySettings.Get("COUNTFINIE"))
     except Exception as e:
         COUNTFINIE = True
     try:
-        TITLEIT = ft(MySettings.Get("TITLEIT"))    
+        TITLEIT = ft(MySettings.Get("TITLEIT"))
     except Exception as e:
         TITLEIT = True
     try:
@@ -2158,15 +2084,15 @@ def LoadSetting():
     except Exception as e:
         TIMEPOPUP = "30"
     try:
-        FORMATARTICLES = ft(MySettings.Get("FORMATARTICLES"))    
+        FORMATARTICLES = ft(MySettings.Get("FORMATARTICLES"))
     except Exception as e:
-        FORMATARTICLES = True    
+        FORMATARTICLES = True
     try:
-        PopUpEditionForm = ft(MySettings.Get("PopUpEditionForm"))    
+        PopUpEditionForm = ft(MySettings.Get("PopUpEditionForm"))
     except Exception as e:
         PopUpEditionForm = False
     try:
-        SerieResumeEverywhere = ft(MySettings.Get("SerieResumeEverywhere"))    
+        SerieResumeEverywhere = ft(MySettings.Get("SerieResumeEverywhere"))
     except Exception as e:
         SerieResumeEverywhere = True
     try:
@@ -2174,7 +2100,7 @@ def LoadSetting():
     except Exception as e:
         PadNumber = "0"
     try:
-        ONESHOTFORMAT = ft(MySettings.Get("ONESHOTFORMAT"))    
+        ONESHOTFORMAT = ft(MySettings.Get("ONESHOTFORMAT"))
     except Exception as e:
         ONESHOTFORMAT = False
     try:
@@ -2186,7 +2112,11 @@ def LoadSetting():
     
     if ONESHOTFORMAT and CBFormat:
         CBFormat = False
-    
+
+    if CBWeb == 2:
+        CBWeb = True
+        ShortWebLink = True
+
     SaveSetting()
 
     aWord = Translate()
@@ -2208,13 +2138,8 @@ def SaveSetting():
     MySettings.Set("CBStatus",  tf(CBStatus))
     MySettings.Set("CBGenre",  tf(CBGenre))
     MySettings.Set("CBNotes",  tf(CBNotes))
-    if CBWeb == True:
-        MySettings.Set("CBWeb",  "1")
-    elif CBWeb == False:
-        MySettings.Set("CBWeb",  "0")
-    elif CBWeb == "2":
-        MySettings.Set("CBWeb",  "2")
-
+    MySettings.Set("CBWeb",  tf(CBWeb))
+    MySettings.Set("ShortWebLink",  tf(ShortWebLink))
     MySettings.Set("CBCount",  tf(CBCount))
     MySettings.Set("CBSynopsys",  tf(CBSynopsys))
     MySettings.Set("CBImprint",  tf(CBImprint))
@@ -2247,13 +2172,7 @@ def SaveSetting():
     MySettings.Set("SerieResumeEverywhere", tf(SerieResumeEverywhere))
     MySettings.Set("AlwaysChooseSerie", tf(AlwaysChooseSerie))
     MySettings.Set("ONESHOTFORMAT", tf(ONESHOTFORMAT))
-
-    if CBStop == True:
-        MySettings.Set("CBStop",  "1")
-    elif CBStop == False:
-        MySettings.Set("CBStop",  "0")
-    elif CBStop == "2":
-        MySettings.Set("CBStop",  "2")
+    MySettings.Set("CBStop", tf(AllowUserChoice))
 
     MySettings.Save((__file__[:-len('BedethequeScraper2.py')] + "App.Config"))
 
@@ -2276,7 +2195,7 @@ class AppSettings(object):
         if ValTrue:
             self.Document.SelectSingleNode("/configuration/" + Name).InnerText = Value
         else:
-            ValNode = self.Document.CreateElement(Name)        
+            ValNode = self.Document.CreateElement(Name)
             ValNode.InnerText = Value
             self.Document.DocumentElement.AppendChild(ValNode)
 
@@ -2319,7 +2238,7 @@ class BDConfigForm(Form):
         self.Name = "BDConfigForm"
         self.Text = "Bedetheque Scraper 2"
         pIcon = (__file__[:-len('BedethequeScraper2.py')] + "BD2.ico")
-        self.Icon = System.Drawing.Icon(pIcon)        
+        self.Icon = System.Drawing.Icon(pIcon)
         self.HelpButton = False
         self.MaximizeBox = False
         self.MinimizeBox = False
@@ -2330,46 +2249,55 @@ class BDConfigForm(Form):
         self._TabData = System.Windows.Forms.TabControl()
         self._tabPage1 = System.Windows.Forms.TabPage()
         self._tabPage2 = System.Windows.Forms.TabPage()
-        self._label5 = System.Windows.Forms.Label()
+        self._tabPage3 = System.Windows.Forms.TabPage()
+        self._labelTags = System.Windows.Forms.Label()
         self._TBTags = System.Windows.Forms.TextBox()
-        self._CBCover = System.Windows.Forms.CheckBox()
-        self._CBCouverture = System.Windows.Forms.CheckBox()        
-        self._CBStatus = System.Windows.Forms.CheckBox()
-        self._CBGenre = System.Windows.Forms.CheckBox()
-        self._CBNotes = System.Windows.Forms.CheckBox()
-        self._CBWeb = System.Windows.Forms.CheckBox()
-        self._CBCount = System.Windows.Forms.CheckBox()
-        self._CBSynopsys = System.Windows.Forms.CheckBox()
-        self._CBImprint = System.Windows.Forms.CheckBox()
-        self._CBLetterer = System.Windows.Forms.CheckBox()
-        self._CBPrinted = System.Windows.Forms.CheckBox()
-        self._CBRating = System.Windows.Forms.CheckBox()
-        self._CBISBN = System.Windows.Forms.CheckBox()
-        self._CBLanguage = System.Windows.Forms.CheckBox()
-        self._CBEditor = System.Windows.Forms.CheckBox()
-        self._CBFormat = System.Windows.Forms.CheckBox()
-        self._CBColorist = System.Windows.Forms.CheckBox()
-        self._CBPenciller = System.Windows.Forms.CheckBox()
-        self._CBWriter = System.Windows.Forms.CheckBox()
-        self._CBTitle = System.Windows.Forms.CheckBox()
-        self._CBSeries = System.Windows.Forms.CheckBox()
+        self._CBDefault = System.Windows.Forms.CheckBox()
+        
+        self._ScrapedDataCheckedListBox = System.Windows.Forms.CheckedListBox()
+        self._scrapedData = collections.OrderedDict(
+            [
+                ('Series', {'label': Trans(71), 'state': if_else(CBSeries, CheckState.Checked, CheckState.Unchecked)}),
+                ('Title', {'label': Trans(72), 'state': if_else(CBTitle, CheckState.Checked, CheckState.Unchecked)}),
+                ('Writer', {'label': Trans(76), 'state': if_else(CBWriter, CheckState.Checked, CheckState.Unchecked)}),
+                ('Penciller', {'label': Trans(74), 'state': if_else(CBPenciller, CheckState.Checked, CheckState.Unchecked)}),
+                ('Colorist', {'label': Trans(75), 'state': if_else(CBColorist, CheckState.Checked, CheckState.Unchecked)}),
+                ('Letterer', {'label': Trans(76), 'state': if_else(CBLetterer, CheckState.Checked, CheckState.Unchecked)}),
+                ('CoverArtist', {'label': Trans(121), 'state': if_else(CBCouverture, CheckState.Checked, CheckState.Unchecked)}),
+                ('Publisher', {'label': Trans(78), 'state': if_else(CBEditor, CheckState.Checked, CheckState.Unchecked)}),
+                ('Language', {'label': Trans(79), 'state': if_else(CBLanguage, CheckState.Checked, CheckState.Unchecked)}),
+                ('Format', {'label': Trans(77), 'state': if_else(CBFormat, CheckState.Checked, CheckState.Unchecked)}),
+                ('Rating', {'label': Trans(81), 'state': if_else(CBRating, CheckState.Checked, CheckState.Unchecked)}),
+                ('Printed', {'label': Trans(82), 'state': if_else(CBPrinted, CheckState.Checked, CheckState.Unchecked)}),
+                ('Imprint', {'label': Trans(83), 'state': if_else(CBImprint, CheckState.Checked, CheckState.Unchecked)}),
+                ('Synopsys', {'label': Trans(84), 'state': if_else(CBSynopsys, CheckState.Checked, CheckState.Unchecked)}),
+                ('Count', {'label': Trans(85), 'state': if_else(CBCount, CheckState.Checked, CheckState.Unchecked)}),
+                ('Notes', {'label': Trans(86), 'state': if_else(CBNotes, CheckState.Checked, CheckState.Unchecked)}),
+                ('SerieStatus', {'label': Trans(87), 'state': if_else(CBStatus, CheckState.Checked, CheckState.Unchecked)}),
+                ('Web', {'label': Trans(88), 'state': if_else(CBWeb, CheckState.Checked, CheckState.Unchecked)}),
+                ('Genre', {'label': Trans(89), 'state': if_else(CBGenre, CheckState.Checked, CheckState.Unchecked)}),
+                ('Cover', {'label': Trans(90), 'state': if_else(CBCover, CheckState.Checked, CheckState.Unchecked)}),
+                ('ISBN', {'label': Trans(80), 'state': if_else(CBISBN, CheckState.Checked, CheckState.Unchecked)})
+            ])
         self._CancelButton = System.Windows.Forms.Button()
         self._OKButton = System.Windows.Forms.Button()
-        self._label1 = System.Windows.Forms.Label()        
-        self._label2 = System.Windows.Forms.Label()        
-        self._label3 = System.Windows.Forms.Label()
-        self._label4 = System.Windows.Forms.Label()        
-        self._label6 = System.Windows.Forms.Label()        
-        self._labelArt = System.Windows.Forms.Label()
-        self._RENLOGMAX = System.Windows.Forms.TextBox()        
+        self._labelDBGLOGMAX = System.Windows.Forms.Label()
+        self._labelRENLOGMAX = System.Windows.Forms.Label()
+        self._labelVersion = System.Windows.Forms.Label()
+        self._labelTIMEOUT = System.Windows.Forms.Label()
+        self._labelTIMEOUTS = System.Windows.Forms.Label()
+        self._labelArticles = System.Windows.Forms.Label()
+        self._RENLOGMAX = System.Windows.Forms.TextBox()
         self._DBGLOGMAX = System.Windows.Forms.TextBox()
         self._DBGONOFF = System.Windows.Forms.CheckBox()
         self._SHOWDBGLOG = System.Windows.Forms.CheckBox()
         self._SHOWRENLOG = System.Windows.Forms.CheckBox()
+        self._labelLanguage = System.Windows.Forms.Label()
         self._radioENG = System.Windows.Forms.RadioButton()
         self._radioFRE = System.Windows.Forms.RadioButton()
         self._PB1 = System.Windows.Forms.PictureBox()
-        self._ButtonReset = System.Windows.Forms.Button()        
+        self._ButtonCheckNone = System.Windows.Forms.Button()
+        self._ButtonCheckAll = System.Windows.Forms.Button()
         self._ARTICLES = System.Windows.Forms.TextBox()
         self._SUBPATT = System.Windows.Forms.TextBox()
         self._labelSUBPATT = System.Windows.Forms.Label()
@@ -2381,18 +2309,21 @@ class BDConfigForm(Form):
         self._SerieResumeEverywhere = System.Windows.Forms.CheckBox()
         self._AlwaysChooseSerie = System.Windows.Forms.CheckBox()
         self._OneShotFormat = System.Windows.Forms.CheckBox()
+        self._ShortWebLink = System.Windows.Forms.CheckBox()
         self._TIMEOUT = System.Windows.Forms.TextBox()
         self._TIMEOUTS = System.Windows.Forms.TextBox()
         self._TIMEPOPUP = System.Windows.Forms.TextBox()
         self._labelTIMEPOPUP = System.Windows.Forms.Label()
         self._PadNumber = System.Windows.Forms.TextBox()
         self._labelPadNumber = System.Windows.Forms.Label()
-        self._CBDefault = System.Windows.Forms.CheckBox()
         self._CBRescrape = System.Windows.Forms.CheckBox()
-        self._CBStop = System.Windows.Forms.CheckBox()
+        self._labelChoice = System.Windows.Forms.GroupBox()
+        self._radioChoiceSkip = System.Windows.Forms.RadioButton()
+        self._radioChoiceUser = System.Windows.Forms.RadioButton()
         self._TabData.SuspendLayout()
         self._tabPage1.SuspendLayout()
         self._tabPage2.SuspendLayout()
+        self._tabPage3.SuspendLayout()
         self._PB1.BeginInit()
         self.SuspendLayout()
         #
@@ -2400,38 +2331,25 @@ class BDConfigForm(Form):
         #
         self._TabData.Controls.Add(self._tabPage1)
         self._TabData.Controls.Add(self._tabPage2)
-        self._TabData.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._TabData.Controls.Add(self._tabPage3)
+        self._TabData.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._TabData.Location = System.Drawing.Point(0, 0)
         self._TabData.Name = "TabData"
         self._TabData.SelectedIndex = 0
-        self._TabData.Size = System.Drawing.Size(512, 412)
+        self._TabData.Size = System.Drawing.Size(612, 362)
         self._TabData.TabIndex = 22
         #
         # tabPage1
         #
         self._tabPage1.Controls.Add(self._PB1)
-        self._tabPage1.Controls.Add(self._CancelButton)
-        self._tabPage1.Controls.Add(self._OKButton)
-        self._tabPage1.Controls.Add(self._label3)
-        self._tabPage1.Controls.Add(self._label2)
-        self._tabPage1.Controls.Add(self._RENLOGMAX)
-        self._tabPage1.Controls.Add(self._label1)
-        self._tabPage1.Controls.Add(self._DBGLOGMAX)
-        self._tabPage1.Controls.Add(self._DBGONOFF)
-        self._tabPage1.Controls.Add(self._SHOWDBGLOG)
-        self._tabPage1.Controls.Add(self._SHOWRENLOG)
+        self._tabPage1.Controls.Add(self._labelLanguage)
         self._tabPage1.Controls.Add(self._radioENG)
         self._tabPage1.Controls.Add(self._radioFRE)
         self._tabPage1.Controls.Add(self._ARTICLES)
-        self._tabPage1.Controls.Add(self._labelArt)
-        self._tabPage1.Controls.Add(self._SUBPATT)
-        self._tabPage1.Controls.Add(self._labelSUBPATT)
-        self._tabPage1.Controls.Add(self._COUNTOF)
-        self._tabPage1.Controls.Add(self._COUNTFINIE)
+        self._tabPage1.Controls.Add(self._labelArticles)
         self._tabPage1.Controls.Add(self._TITLEIT)
         self._tabPage1.Controls.Add(self._FORMATARTICLES)
         self._tabPage1.Controls.Add(self._PopUpEditionForm)
-        self._tabPage1.Controls.Add(self._SerieResumeEverywhere)
         self._tabPage1.Controls.Add(self._AlwaysChooseSerie)
         self._tabPage1.Controls.Add(self._TIMEOUT)
         self._tabPage1.Controls.Add(self._TIMEOUTS)
@@ -2439,14 +2357,16 @@ class BDConfigForm(Form):
         self._tabPage1.Controls.Add(self._labelTIMEPOPUP)
         self._tabPage1.Controls.Add(self._PadNumber)
         self._tabPage1.Controls.Add(self._labelPadNumber)
-        self._tabPage1.Controls.Add(self._label4)
-        self._tabPage1.Controls.Add(self._label6)
+        self._tabPage1.Controls.Add(self._labelTIMEOUT)
+        self._tabPage1.Controls.Add(self._labelTIMEOUTS)
         self._tabPage1.Controls.Add(self._CBRescrape)
-        self._tabPage1.Controls.Add(self._CBStop)
+        self._tabPage1.Controls.Add(self._labelChoice)
+        self._labelChoice.Controls.Add(self._radioChoiceSkip)
+        self._labelChoice.Controls.Add(self._radioChoiceUser)
         self._tabPage1.Location = System.Drawing.Point(4, 22)
         self._tabPage1.Name = "tabPage1"
         self._tabPage1.Padding = System.Windows.Forms.Padding(3)
-        self._tabPage1.Size = System.Drawing.Size(500, 400)
+        self._tabPage1.Size = System.Drawing.Size(600, 350)
         self._tabPage1.TabIndex = 0
         self._tabPage1.Text = Trans(95)
         self._tabPage1.UseVisualStyleBackColor = True
@@ -2454,318 +2374,106 @@ class BDConfigForm(Form):
         #
         # tabPage2
         #
-        self._tabPage2.Controls.Add(self._ButtonReset)
-        self._tabPage2.Controls.Add(self._label5)
+        self._tabPage2.Controls.Add(self._ButtonCheckNone)
+        self._tabPage2.Controls.Add(self._ButtonCheckAll)
+        self._tabPage2.Controls.Add(self._labelTags)
         self._tabPage2.Controls.Add(self._TBTags)
-        self._tabPage2.Controls.Add(self._CBCover)
-        self._tabPage2.Controls.Add(self._CBCouverture)
-        self._tabPage2.Controls.Add(self._CBStatus)
-        self._tabPage2.Controls.Add(self._CBGenre)
-        self._tabPage2.Controls.Add(self._CBNotes)
-        self._tabPage2.Controls.Add(self._CBWeb)
-        self._tabPage2.Controls.Add(self._CBCount)
-        self._tabPage2.Controls.Add(self._CBSynopsys)
-        self._tabPage2.Controls.Add(self._CBImprint)
-        self._tabPage2.Controls.Add(self._CBLetterer)
-        self._tabPage2.Controls.Add(self._CBPrinted)
-        self._tabPage2.Controls.Add(self._CBRating)
-        self._tabPage2.Controls.Add(self._CBISBN)
-        self._tabPage2.Controls.Add(self._CBLanguage)
-        self._tabPage2.Controls.Add(self._CBEditor)
-        self._tabPage2.Controls.Add(self._CBFormat)
-        self._tabPage2.Controls.Add(self._CBColorist)
-        self._tabPage2.Controls.Add(self._CBPenciller)
-        self._tabPage2.Controls.Add(self._CBWriter)
-        self._tabPage2.Controls.Add(self._CBTitle)
-        self._tabPage2.Controls.Add(self._CBSeries)
         self._tabPage2.Controls.Add(self._CBDefault)
         self._tabPage2.Controls.Add(self._OneShotFormat)
+        self._tabPage2.Controls.Add(self._ScrapedDataCheckedListBox)
+        self._tabPage2.Controls.Add(self._ShortWebLink)
+        self._tabPage2.Controls.Add(self._COUNTOF)
+        self._tabPage2.Controls.Add(self._COUNTFINIE)
+        self._tabPage2.Controls.Add(self._SerieResumeEverywhere)
+        self._tabPage2.Controls.Add(self._SUBPATT)
+        self._tabPage2.Controls.Add(self._labelSUBPATT)
         self._tabPage2.Location = System.Drawing.Point(4, 22)
         self._tabPage2.Name = "tabPage2"
         self._tabPage2.Padding = System.Windows.Forms.Padding(3)
-        self._tabPage2.Size = System.Drawing.Size(500, 400)
+        self._tabPage2.Size = System.Drawing.Size(600, 350)
         self._tabPage2.TabIndex = 1
         self._tabPage2.Text = Trans(96)
         self._tabPage2.UseVisualStyleBackColor = True
         self._tabPage2.Tag = "Tab"
         #
-        # label5
+        # tabPage3
         #
-        self._label5.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._label5.Location = System.Drawing.Point(352, 181)
-        self._label5.Name = "label5"
-        self._label5.Size = System.Drawing.Size(56, 24)
-        self._label5.TabIndex = 99
-        self._label5.Text = Trans(91)
-        self._label5.Tag = "Label"
-        self._label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
+        self._tabPage3.Controls.Add(self._labelRENLOGMAX)
+        self._tabPage3.Controls.Add(self._RENLOGMAX)
+        self._tabPage3.Controls.Add(self._labelDBGLOGMAX)
+        self._tabPage3.Controls.Add(self._DBGLOGMAX)
+        self._tabPage3.Controls.Add(self._DBGONOFF)
+        self._tabPage3.Controls.Add(self._SHOWDBGLOG)
+        self._tabPage3.Controls.Add(self._SHOWRENLOG)
+        self._tabPage3.Location = System.Drawing.Point(4, 22)
+        self._tabPage3.Name = "tabPage3"
+        self._tabPage3.Padding = System.Windows.Forms.Padding(3)
+        self._tabPage3.Size = System.Drawing.Size(600, 350)
+        self._tabPage3.TabIndex = 1
+        self._tabPage3.Text = Trans(47)
+        self._tabPage3.UseVisualStyleBackColor = True
+        self._tabPage3.Tag = "Tab"
+        #
+        # ScrapedDataCheckedListBox
+        #
+        self._ScrapedDataCheckedListBox.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._ScrapedDataCheckedListBox.Location = System.Drawing.Point(8, 8)
+        self._ScrapedDataCheckedListBox.Size = System.Drawing.Size(250, 300)
+        self._ScrapedDataCheckedListBox.Name = "ScrapedDataCheckedListBox"
+        self._ScrapedDataCheckedListBox.TabIndex = 10
+        self._ScrapedDataCheckedListBox.CheckOnClick = True
+        self._ScrapedDataCheckedListBox.ItemCheck += self.ScrapedDataCheckedListBox_CheckItem
+        for key, item in self._scrapedData.items():
+            self._ScrapedDataCheckedListBox.Items.Add(self._scrapedData[key]['label'], self._scrapedData[key]['state'])
+        #
+        # labelTags
+        #
+        self._labelTags.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelTags.Location = System.Drawing.Point(268, 176)
+        self._labelTags.Name = "labelTags"
+        self._labelTags.Size = System.Drawing.Size(120, 24)
+        self._labelTags.TabIndex = 99
+        self._labelTags.Text = Trans(91)
+        self._labelTags.Tag = "Label"
+        self._labelTags.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
         #
         # TBTags
         #
         self._TBTags.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._TBTags.Location = System.Drawing.Point(352, 211)
+        self._TBTags.Location = System.Drawing.Point(396, 180)
         self._TBTags.MaxLength = 255
         self._TBTags.Name = "TBTags"
-        self._TBTags.Size = System.Drawing.Size(80, 20)
+        self._TBTags.Size = System.Drawing.Size(200, 20)
         self._TBTags.TabIndex = 40
         self._TBTags.Text = TBTags
         #
+        # ShortWebLink
+        #
+        self._ShortWebLink.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._ShortWebLink.Location = System.Drawing.Point(268, 148)
+        self._ShortWebLink.Name = "ShortWebLink"
+        self._ShortWebLink.Size = System.Drawing.Size(350, 24)
+        self._ShortWebLink.Text = Trans(48)
+        self._ShortWebLink.UseVisualStyleBackColor = True
+        self._ShortWebLink.CheckState = if_else(ShortWebLink, CheckState.Checked, CheckState.Unchecked)
+        #
         # CBDefault
         #
-        self._CBDefault.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBDefault.Location = System.Drawing.Point(352, 11)
+        self._CBDefault.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._CBDefault.Location = System.Drawing.Point(268, 36)
         self._CBDefault.Name = "CBDefault"
-        self._CBDefault.Size = System.Drawing.Size(104, 24)
+        self._CBDefault.Size = System.Drawing.Size(350, 24)
         self._CBDefault.TabIndex = 38
         self._CBDefault.Text = Trans(136)
         self._CBDefault.UseVisualStyleBackColor = True
         self._CBDefault.CheckState = if_else(CBDefault, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBCover
-        #
-        self._CBCover.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBCover.Location = System.Drawing.Point(240, 211)
-        self._CBCover.Name = "CBCover"
-        self._CBCover.Size = System.Drawing.Size(104, 24)
-        self._CBCover.TabIndex = 38
-        self._CBCover.Text = Trans(90)
-        self._CBCover.UseVisualStyleBackColor = True
-        self._CBCover.CheckState = if_else(CBCover, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBCouverture
-        #
-        self._CBCouverture.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBCouverture.Location = System.Drawing.Point(16, 251)
-        self._CBCouverture.Name = "CBCouverture"
-        self._CBCouverture.Size = System.Drawing.Size(104, 24)
-        self._CBCouverture.TabIndex = 14
-        self._CBCouverture.Text = Trans(121)
-        self._CBCouverture.UseVisualStyleBackColor = True
-        self._CBCouverture.CheckState = if_else(CBCover, CheckState.Checked, CheckState.Unchecked)        
-        #
-        # CBStatus
-        #
-        self._CBStatus.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBStatus.Location = System.Drawing.Point(240, 91)
-        self._CBStatus.Name = "CBStatus"
-        self._CBStatus.Size = System.Drawing.Size(104, 24)
-        self._CBStatus.TabIndex = 23
-        self._CBStatus.Text = Trans(87)
-        self._CBStatus.UseVisualStyleBackColor = True
-        self._CBStatus.CheckState = if_else(CBStatus, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBGenre
-        #
-        self._CBGenre.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBGenre.Location = System.Drawing.Point(240, 171)
-        self._CBGenre.Name = "CBGenre"
-        self._CBGenre.Size = System.Drawing.Size(104, 24)
-        self._CBGenre.TabIndex = 37
-        self._CBGenre.Text = Trans(89)
-        self._CBGenre.UseVisualStyleBackColor = True
-        self._CBGenre.CheckState = if_else(CBGenre, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBNotes
-        #
-        self._CBNotes.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBNotes.Location = System.Drawing.Point(240, 51)
-        self._CBNotes.Name = "CBNotes"
-        self._CBNotes.Size = System.Drawing.Size(104, 24)
-        self._CBNotes.TabIndex = 22
-        self._CBNotes.Text = Trans(86)
-        self._CBNotes.UseVisualStyleBackColor = True
-        self._CBNotes.CheckState = if_else(CBNotes, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBWeb
-        #
-        self._CBWeb.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBWeb.Location = System.Drawing.Point(240, 131)
-        self._CBWeb.Name = "CBWeb"
-        self._CBWeb.Size = System.Drawing.Size(104, 24)
-        self._CBWeb.TabIndex = 36
-        self._CBWeb.Text = Trans(88)
-        self._CBWeb.UseVisualStyleBackColor = True
-        self._CBWeb.ThreeState = True
-        if CBWeb == True:
-            self._CBWeb.CheckState = CheckState.Checked
-        elif  CBWeb == False:
-            self._CBWeb.CheckState = CheckState.Unchecked
-        elif CBWeb == "2":
-            self._CBWeb.CheckState = CheckState.Indeterminate
-        #self._CBWeb.CheckState = if_else(CBWeb, CheckState.Checked, CheckState.Unchecked)
-
-        #
-        # CBCount
-        #
-        self._CBCount.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBCount.Location = System.Drawing.Point(240, 11)
-        self._CBCount.Name = "CBCount"
-        self._CBCount.Size = System.Drawing.Size(104, 24)
-        self._CBCount.TabIndex = 21
-        self._CBCount.Text = Trans(85)
-        self._CBCount.UseVisualStyleBackColor = True
-        self._CBCount.CheckState = if_else(CBCount, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBSynopsys
-        #
-        self._CBSynopsys.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBSynopsys.Location = System.Drawing.Point(128, 251)
-        self._CBSynopsys.Name = "CBSynopsys"
-        self._CBSynopsys.Size = System.Drawing.Size(104, 24)
-        self._CBSynopsys.TabIndex = 20
-        self._CBSynopsys.Text = Trans(84)
-        self._CBSynopsys.UseVisualStyleBackColor = True
-        self._CBSynopsys.CheckState = if_else(CBSynopsys, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBImprint
-        #
-        self._CBImprint.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBImprint.Location = System.Drawing.Point(128, 211)
-        self._CBImprint.Name = "CBImprint"
-        self._CBImprint.Size = System.Drawing.Size(104, 24)
-        self._CBImprint.TabIndex = 19
-        self._CBImprint.Text = Trans(83)
-        self._CBImprint.UseVisualStyleBackColor = True
-        self._CBImprint.CheckState = if_else(CBImprint, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBLetterer
-        #
-        self._CBLetterer.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBLetterer.Location = System.Drawing.Point(16, 211)
-        self._CBLetterer.Name = "CBLetterer"
-        self._CBLetterer.Size = System.Drawing.Size(104, 24)
-        self._CBLetterer.TabIndex = 13
-        self._CBLetterer.Text = Trans(76)
-        self._CBLetterer.UseVisualStyleBackColor = True
-        self._CBLetterer.CheckState = if_else(CBLetterer, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBPrinted
-        #
-        self._CBPrinted.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBPrinted.Location = System.Drawing.Point(128, 171)
-        self._CBPrinted.Name = "CBPrinted"
-        self._CBPrinted.Size = System.Drawing.Size(104, 24)
-        self._CBPrinted.TabIndex = 18
-        self._CBPrinted.Text = Trans(82)
-        self._CBPrinted.UseVisualStyleBackColor = True
-        self._CBPrinted.CheckState = if_else(CBPrinted, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBRating
-        #
-        self._CBRating.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBRating.Location = System.Drawing.Point(128, 131)
-        self._CBRating.Name = "CBRating"
-        self._CBRating.Size = System.Drawing.Size(104, 24)
-        self._CBRating.TabIndex = 17
-        self._CBRating.Text = Trans(81)
-        self._CBRating.UseVisualStyleBackColor = True
-        self._CBRating.CheckState = if_else(CBRating, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBISBN
-        #
-        self._CBISBN.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBISBN.Location = System.Drawing.Point(240, 251)
-        self._CBISBN.Name = "CBISBN"
-        self._CBISBN.Size = System.Drawing.Size(104, 24)
-        self._CBISBN.TabIndex = 39
-        self._CBISBN.Text = Trans(80)
-        self._CBISBN.UseVisualStyleBackColor = True
-        self._CBISBN.CheckState = if_else(CBISBN, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBLanguage
-        #
-        self._CBLanguage.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBLanguage.Location = System.Drawing.Point(128, 51)
-        self._CBLanguage.Name = "CBLanguage"
-        self._CBLanguage.Size = System.Drawing.Size(104, 24)
-        self._CBLanguage.TabIndex = 15
-        self._CBLanguage.Text = Trans(79)
-        self._CBLanguage.UseVisualStyleBackColor = True
-        self._CBLanguage.CheckState = if_else(CBLanguage, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBEditor
-        #
-        self._CBEditor.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBEditor.Location = System.Drawing.Point(128, 11)
-        self._CBEditor.Name = "CBEditor"
-        self._CBEditor.Size = System.Drawing.Size(104, 24)
-        self._CBEditor.TabIndex = 14
-        self._CBEditor.Text = Trans(78)
-        self._CBEditor.UseVisualStyleBackColor = True
-        self._CBEditor.CheckState = if_else(CBEditor, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBFormat
-        #
-        self._CBFormat.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBFormat.Location = System.Drawing.Point(128, 91)
-        self._CBFormat.Name = "CBFormat"
-        self._CBFormat.Size = System.Drawing.Size(104, 24)
-        self._CBFormat.TabIndex = 16
-        self._CBFormat.Text = Trans(77)
-        self._CBFormat.UseVisualStyleBackColor = True
-        self._CBFormat.CheckState = if_else(CBFormat, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBColorist
-        #
-        self._CBColorist.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBColorist.Location = System.Drawing.Point(16, 171)
-        self._CBColorist.Name = "CBColorist"
-        self._CBColorist.Size = System.Drawing.Size(104, 24)
-        self._CBColorist.TabIndex = 12
-        self._CBColorist.Text = Trans(75)
-        self._CBColorist.UseVisualStyleBackColor = True
-        self._CBColorist.CheckState = if_else(CBColorist, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBPenciller
-        #
-        self._CBPenciller.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBPenciller.Location = System.Drawing.Point(16, 131)
-        self._CBPenciller.Name = "CBPenciller"
-        self._CBPenciller.Size = System.Drawing.Size(104, 24)
-        self._CBPenciller.TabIndex = 11
-        self._CBPenciller.Text = Trans(74)
-        self._CBPenciller.UseVisualStyleBackColor = True
-        self._CBPenciller.CheckState = if_else(CBPenciller, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBWriter
-        #
-        self._CBWriter.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBWriter.Location = System.Drawing.Point(16, 91)
-        self._CBWriter.Name = "CBWriter"
-        self._CBWriter.Size = System.Drawing.Size(104, 24)
-        self._CBWriter.TabIndex = 10
-        self._CBWriter.Text = Trans(73)
-        self._CBWriter.UseVisualStyleBackColor = True
-        self._CBWriter.CheckState = if_else(CBWriter, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBTitle
-        #
-        self._CBTitle.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBTitle.Location = System.Drawing.Point(16, 51)
-        self._CBTitle.Name = "CBTitle"
-        self._CBTitle.Size = System.Drawing.Size(104, 24)
-        self._CBTitle.TabIndex = 9
-        self._CBTitle.Text = Trans(72)
-        self._CBTitle.UseVisualStyleBackColor = True
-        self._CBTitle.CheckState = if_else(CBTitle, CheckState.Checked, CheckState.Unchecked)
-        #
-        # CBSeries
-        #
-        self._CBSeries.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBSeries.Location = System.Drawing.Point(16, 11)
-        self._CBSeries.Name = "CBSeries"
-        self._CBSeries.Size = System.Drawing.Size(104, 24)
-        self._CBSeries.TabIndex = 8
-        self._CBSeries.Text = Trans(71)
-        self._CBSeries.UseVisualStyleBackColor = True
-        self._CBSeries.CheckState = if_else(CBSeries, CheckState.Checked, CheckState.Unchecked)
         #
         # CancelButton
         #
         self._CancelButton.BackColor = System.Drawing.Color.Red
         self._CancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel
         self._CancelButton.Font = System.Drawing.Font("Microsoft Sans Serif", 9, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0)
-        self._CancelButton.Location = System.Drawing.Point(420, 350)
+        self._CancelButton.Location = System.Drawing.Point(520, 370)
         self._CancelButton.Name = "CancelButton"
         self._CancelButton.Size = System.Drawing.Size(75, 32)
         self._CancelButton.TabIndex = 30
@@ -2778,7 +2486,7 @@ class BDConfigForm(Form):
         self._OKButton.DialogResult = System.Windows.Forms.DialogResult.OK
         self._OKButton.Font = System.Drawing.Font("Microsoft Sans Serif", 9, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0)
         self._OKButton.ForeColor = System.Drawing.Color.Black
-        self._OKButton.Location = System.Drawing.Point(8, 350)
+        self._OKButton.Location = System.Drawing.Point(16, 370)
         self._OKButton.Name = "OKButton"
         self._OKButton.Size = System.Drawing.Size(75, 32)
         self._OKButton.TabIndex = 29
@@ -2786,99 +2494,115 @@ class BDConfigForm(Form):
         self._OKButton.UseVisualStyleBackColor = False
         self._OKButton.Click += self.button_Click
         #
-        # ButtonReset
+        # ButtonCheckNone
         #
-        self._ButtonReset.BackColor = System.Drawing.Color.FromArgb(255, 192, 128)
-        self._ButtonReset.Font = System.Drawing.Font("Microsoft Sans Serif", 9, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0)
-        self._ButtonReset.Location = System.Drawing.Point(352, 128)
-        self._ButtonReset.Name = "ButtonReset"
-        self._ButtonReset.Size = System.Drawing.Size(75, 30)
-        self._ButtonReset.TabIndex = 53
-        self._ButtonReset.Text = Trans(94)
-        self._ButtonReset.UseVisualStyleBackColor = False
-        self._ButtonReset.Tag = "Button"
-        self._ButtonReset.Click += self.button_Click
+        self._ButtonCheckNone.BackColor = System.Drawing.Color.FromArgb(255, 192, 128)
+        self._ButtonCheckNone.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._ButtonCheckNone.Location = System.Drawing.Point(8, 308)
+        self._ButtonCheckNone.Name = "ButtonCheckNone"
+        self._ButtonCheckNone.Size = System.Drawing.Size(120, 20)
+        self._ButtonCheckNone.TabIndex = 53
+        self._ButtonCheckNone.Text = Trans(94)
+        self._ButtonCheckNone.UseVisualStyleBackColor = False
+        self._ButtonCheckNone.Tag = "Button"
+        self._ButtonCheckNone.Click += self.button_Click
         #
-        # label3
+        # ButtonCheckAll
         #
-        self._label3.Font = System.Drawing.Font("Microsoft Sans Serif", 6.75, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._label3.ImageAlign = System.Drawing.ContentAlignment.BottomCenter
-        self._label3.Location = System.Drawing.Point(114, 360)
-        self._label3.Name = "label3"
-        self._label3.Size = System.Drawing.Size(264, 16)
-        self._label3.TabIndex = 19
-        self._label3.Text = "Version " + VERSION + " (c) 2021 kiwi13 && maforget"
-        self._label3.TextAlign = System.Drawing.ContentAlignment.BottomCenter
+        self._ButtonCheckAll.BackColor = System.Drawing.Color.FromArgb(255, 192, 128)
+        self._ButtonCheckAll.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._ButtonCheckAll.Location = System.Drawing.Point(132, 308)
+        self._ButtonCheckAll.Name = "ButtonCheckAll"
+        self._ButtonCheckAll.Size = System.Drawing.Size(120, 20)
+        self._ButtonCheckAll.TabIndex = 52
+        self._ButtonCheckAll.Text = Trans(117)
+        self._ButtonCheckAll.UseVisualStyleBackColor = False
+        self._ButtonCheckAll.Tag = "Button"
+        self._ButtonCheckAll.Click += self.button_Click
         #
-        # label1
+        # labelVersion
         #
-        self._label1.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._label1.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._label1.Location = System.Drawing.Point(96, 120)
-        self._label1.Name = "label1"
-        self._label1.Size = System.Drawing.Size(124, 21)
-        self._label1.TabIndex = 16
-        self._label1.Text = Trans(69)
+        self._labelVersion.Font = System.Drawing.Font("Microsoft Sans Serif", 6.75, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelVersion.ImageAlign = System.Drawing.ContentAlignment.BottomCenter
+        self._labelVersion.Location = System.Drawing.Point(162, 380)
+        self._labelVersion.Name = "labelVersion"
+        self._labelVersion.Size = System.Drawing.Size(264, 16)
+        self._labelVersion.TabIndex = 19
+        self._labelVersion.Text = "Version " + VERSION + " (c) 2021 kiwi13 && maforget"
+        self._labelVersion.TextAlign = System.Drawing.ContentAlignment.BottomCenter
+        #
+        # labelDBGLOGMAX
+        #
+        self._labelDBGLOGMAX.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelDBGLOGMAX.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
+        self._labelDBGLOGMAX.Location = System.Drawing.Point(8, 124)
+        self._labelDBGLOGMAX.Name = "labelDBGLOGMAX"
+        self._labelDBGLOGMAX.Size = System.Drawing.Size(270, 21)
+        self._labelDBGLOGMAX.TabIndex = 16
+        self._labelDBGLOGMAX.Text = Trans(69)
         #
         # DBGLOGMAX
         #
-        self._DBGLOGMAX.Location = System.Drawing.Point(8, 120)
+        self._DBGLOGMAX.Location = System.Drawing.Point(300, 122)
         self._DBGLOGMAX.Name = "DBGLOGMAX"
-        self._DBGLOGMAX.Size = System.Drawing.Size(72, 23)
+        self._DBGLOGMAX.Size = System.Drawing.Size(40, 23)
         self._DBGLOGMAX.TabIndex = 4
-        self._DBGLOGMAX.Text = str(DBGLOGMAX)
+        self._DBGLOGMAX.TextAlign = HorizontalAlignment.Center
+        self._DBGLOGMAX.Text = str(int(DBGLOGMAX / 1024 / 1024))
         #
-        # labelArt
+        # labelArticles
         #
-        self._labelArt.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._labelArt.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelArt.Location = System.Drawing.Point(250, 80)
-        self._labelArt.Name = "labelArt"
-        self._labelArt.Size = System.Drawing.Size(184, 17)
-        self._labelArt.TabIndex = 18
-        self._labelArt.Text = Trans(109)
+        self._labelArticles.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelArticles.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
+        self._labelArticles.Location = System.Drawing.Point(8, 72)
+        self._labelArticles.Name = "labelArticles"
+        self._labelArticles.Size = System.Drawing.Size(110, 24)
+        self._labelArticles.TabIndex = 18
+        self._labelArticles.Text = Trans(109)
         #
         # ARTICLES
         #
-        self._ARTICLES.Location = System.Drawing.Point(320, 80)
+        self._ARTICLES.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._ARTICLES.Location = System.Drawing.Point(118, 70)
         self._ARTICLES.Name = "ARTICLES"
-        self._ARTICLES.Size = System.Drawing.Size(180, 20)
+        self._ARTICLES.Size = System.Drawing.Size(200, 20)
         self._ARTICLES.TabIndex = 19
         self._ARTICLES.Text = ARTICLES
         #
         # label chaine à supp
         #
-        self._labelSUBPATT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelSUBPATT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelSUBPATT.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelSUBPATT.Location = System.Drawing.Point(8, 324)
+        self._labelSUBPATT.Location = System.Drawing.Point(268, 208)
         self._labelSUBPATT.Name = "labelSubPatt"
-        self._labelSUBPATT.Size = System.Drawing.Size(184, 17)
+        self._labelSUBPATT.Size = System.Drawing.Size(250, 24)
         self._labelSUBPATT.TabIndex = 100
         self._labelSUBPATT.Text = Trans(37)
         #
         # Pattern a supp
         #
-        self._SUBPATT.Location = System.Drawing.Point(180, 320)
+        self._SUBPATT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._SUBPATT.Location = System.Drawing.Point(480, 206)
         self._SUBPATT.Name = "PATTSUB"
-        self._SUBPATT.Size = System.Drawing.Size(130, 20)
+        self._SUBPATT.Size = System.Drawing.Size(116, 20)
         self._SUBPATT.TabIndex = 101
         self._SUBPATT.Text = SUBPATT
         #
         # label time out popup
         #
-        self._labelTIMEPOPUP.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelTIMEPOPUP.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelTIMEPOPUP.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelTIMEPOPUP.Location = System.Drawing.Point(8, 266)
+        self._labelTIMEPOPUP.Location = System.Drawing.Point(320, 246)
         self._labelTIMEPOPUP.Name = "labelTimePopup"
-        self._labelTIMEPOPUP.Size = System.Drawing.Size(184, 17)
+        self._labelTIMEPOPUP.Size = System.Drawing.Size(200, 23)
         self._labelTIMEPOPUP.TabIndex = 102
         self._labelTIMEPOPUP.Text = Trans(44)
         #
         # time out popup
         #
-        self._TIMEPOPUP.Location = System.Drawing.Point(180, 262)
+        self._TIMEPOPUP.Location = System.Drawing.Point(550, 244)
         self._TIMEPOPUP.Name = "TIMEPOPUP"
-        self._TIMEPOPUP.Size = System.Drawing.Size(50, 20)
+        self._TIMEPOPUP.Size = System.Drawing.Size(40, 20)
         self._TIMEPOPUP.TabIndex = 103
         self._TIMEPOPUP.MaxLength = 3
         self._TIMEPOPUP.TextAlign = HorizontalAlignment.Center
@@ -2886,48 +2610,49 @@ class BDConfigForm(Form):
         #
         # label pad number
         #
-        self._labelPadNumber.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelPadNumber.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
         self._labelPadNumber.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._labelPadNumber.Location = System.Drawing.Point(8, 295)
+        self._labelPadNumber.Location = System.Drawing.Point(8, 274)
         self._labelPadNumber.Name = "labelPadNumber"
-        self._labelPadNumber.Size = System.Drawing.Size(184, 23)
+        self._labelPadNumber.Size = System.Drawing.Size(260, 23)
         self._labelPadNumber.TabIndex = 104
         self._labelPadNumber.Text = Trans(148)
         #
         # pad number
         #
-        self._PadNumber.Location = System.Drawing.Point(180, 291)
+        self._PadNumber.Location = System.Drawing.Point(268, 272)
         self._PadNumber.Name = "PadNumber"
-        self._PadNumber.Size = System.Drawing.Size(50, 20)
+        self._PadNumber.Size = System.Drawing.Size(40, 20)
         self._PadNumber.TabIndex = 105
         self._PadNumber.MaxLength = 3
         self._PadNumber.TextAlign = HorizontalAlignment.Center
         self._PadNumber.Text = PadNumber
         #
-        # label2
+        # labelRENLOGMAX
         #
-        self._label2.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._label2.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._label2.Location = System.Drawing.Point(96, 160)
-        self._label2.Name = "label2"
-        self._label2.Size = System.Drawing.Size(124, 21)
-        self._label2.TabIndex = 20
-        self._label2.Text = Trans(70)
+        self._labelRENLOGMAX.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelRENLOGMAX.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
+        self._labelRENLOGMAX.Location = System.Drawing.Point(8, 96)
+        self._labelRENLOGMAX.Name = "labelRENLOGMAX"
+        self._labelRENLOGMAX.Size = System.Drawing.Size(270, 21)
+        self._labelRENLOGMAX.TabIndex = 20
+        self._labelRENLOGMAX.Text = Trans(70)
         #
         # RENLOGMAX
         #
-        self._RENLOGMAX.Location = System.Drawing.Point(8, 160)
+        self._RENLOGMAX.Location = System.Drawing.Point(300, 94)
         self._RENLOGMAX.Name = "RENLOGMAX"
-        self._RENLOGMAX.Size = System.Drawing.Size(72, 23)
+        self._RENLOGMAX.Size = System.Drawing.Size(40, 23)
         self._RENLOGMAX.TabIndex = 5
-        self._RENLOGMAX.Text = str(RENLOGMAX)
+        self._RENLOGMAX.TextAlign = HorizontalAlignment.Center
+        self._RENLOGMAX.Text = str(int(RENLOGMAX / 1024 / 1024))
         #
         # CBRescrape
         #
-        self._CBRescrape.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBRescrape.Location = System.Drawing.Point(320, 105)
+        self._CBRescrape.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._CBRescrape.Location = System.Drawing.Point(8, 302)
         self._CBRescrape.Name = "CBRescrape"
-        self._CBRescrape.Size = System.Drawing.Size(180, 20)
+        self._CBRescrape.Size = System.Drawing.Size(400, 20)
         self._CBRescrape.TabIndex = 21
         self._CBRescrape.Text = Trans(137)
         self._CBRescrape.UseVisualStyleBackColor = True
@@ -2935,21 +2660,21 @@ class BDConfigForm(Form):
         #
         # COUNTOF
         #
-        self._COUNTOF.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._COUNTOF.Location = System.Drawing.Point(320, 128)
+        self._COUNTOF.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._COUNTOF.Location = System.Drawing.Point(268, 64)
         self._COUNTOF.Name = "COUNTOF"
-        self._COUNTOF.Size = System.Drawing.Size(180, 20)
+        self._COUNTOF.Size = System.Drawing.Size(350, 20)
         self._COUNTOF.TabIndex = 22
         self._COUNTOF.Text = Trans(110)
         self._COUNTOF.UseVisualStyleBackColor = True
-        self._COUNTOF.CheckState = if_else(COUNTOF, CheckState.Checked, CheckState.Unchecked)        
+        self._COUNTOF.CheckState = if_else(COUNTOF, CheckState.Checked, CheckState.Unchecked)
         #
         # COUNTFINIE
         #
-        self._COUNTFINIE.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._COUNTFINIE.Location = System.Drawing.Point(320, 150)
+        self._COUNTFINIE.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._COUNTFINIE.Location = System.Drawing.Point(268, 92)
         self._COUNTFINIE.Name = "COUNTFINIE"
-        self._COUNTFINIE.Size = System.Drawing.Size(180, 20)
+        self._COUNTFINIE.Size = System.Drawing.Size(350, 20)
         self._COUNTFINIE.TabIndex = 23
         self._COUNTFINIE.Text = Trans(126)
         self._COUNTFINIE.UseVisualStyleBackColor = True
@@ -2957,10 +2682,10 @@ class BDConfigForm(Form):
         #
         # TITLEIT
         #
-        self._TITLEIT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._TITLEIT.Location = System.Drawing.Point(320, 172)
+        self._TITLEIT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._TITLEIT.Location = System.Drawing.Point(8, 96)
         self._TITLEIT.Name = "TITLEIT"
-        self._TITLEIT.Size = System.Drawing.Size(180, 20)
+        self._TITLEIT.Size = System.Drawing.Size(350, 24)
         self._TITLEIT.TabIndex = 24
         self._TITLEIT.Text = Trans(127)
         self._TITLEIT.UseVisualStyleBackColor = True
@@ -2968,10 +2693,10 @@ class BDConfigForm(Form):
         #
         # FORMATARTICLES
         #
-        self._FORMATARTICLES.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._FORMATARTICLES.Location = System.Drawing.Point(320, 194)
+        self._FORMATARTICLES.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._FORMATARTICLES.Location = System.Drawing.Point(8, 40)
         self._FORMATARTICLES.Name = "FORMATARTICLES"
-        self._FORMATARTICLES.Size = System.Drawing.Size(180, 20)
+        self._FORMATARTICLES.Size = System.Drawing.Size(320, 24)
         self._FORMATARTICLES.TabIndex = 25
         self._FORMATARTICLES.Text = Trans(144)
         self._FORMATARTICLES.UseVisualStyleBackColor = True
@@ -2979,10 +2704,10 @@ class BDConfigForm(Form):
         #
         # PopUpEditionForm
         #
-        self._PopUpEditionForm.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._PopUpEditionForm.Location = System.Drawing.Point(320, 216)
+        self._PopUpEditionForm.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._PopUpEditionForm.Location = System.Drawing.Point(8, 160)
         self._PopUpEditionForm.Name = "PopUpEditionForm"
-        self._PopUpEditionForm.Size = System.Drawing.Size(180, 20)
+        self._PopUpEditionForm.Size = System.Drawing.Size(320, 20)
         self._PopUpEditionForm.TabIndex = 26
         self._PopUpEditionForm.Text = Trans(147)
         self._PopUpEditionForm.UseVisualStyleBackColor = True
@@ -2990,38 +2715,54 @@ class BDConfigForm(Form):
         #
         # SerieResumeEverywhere
         #
-        self._SerieResumeEverywhere.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._SerieResumeEverywhere.Location = System.Drawing.Point(320, 238)
+        self._SerieResumeEverywhere.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._SerieResumeEverywhere.Location = System.Drawing.Point(268, 120)
         self._SerieResumeEverywhere.Name = "SerieResumeEverywhere"
-        self._SerieResumeEverywhere.Size = System.Drawing.Size(180, 20)
+        self._SerieResumeEverywhere.Size = System.Drawing.Size(350, 20)
         self._SerieResumeEverywhere.TabIndex = 27
         self._SerieResumeEverywhere.Text = Trans(149)
         self._SerieResumeEverywhere.UseVisualStyleBackColor = True
         self._SerieResumeEverywhere.CheckState = if_else(SerieResumeEverywhere, CheckState.Unchecked, CheckState.Checked)
         #
-        # Stop at error scraping
+        # labelChoice (Decision in case of multiple choices when scraping)
         #
-        self._CBStop.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._CBStop.Location = System.Drawing.Point(320, 260)
-        self._CBStop.Name = "CBStop"
-        self._CBStop.Size = System.Drawing.Size(180, 20)
-        self._CBStop.TabIndex = 28
-        self._CBStop.Text = Trans(141)
-        self._CBStop.UseVisualStyleBackColor = True
-        self._CBStop.ThreeState = True
-        if CBStop == True:
-            self._CBStop.CheckState = CheckState.Checked
-        elif  CBStop == False:
-            self._CBStop.CheckState = CheckState.Unchecked
-        elif CBStop == "2":
-            self._CBStop.CheckState = CheckState.Indeterminate
+        self._labelChoice.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelChoice.Location = System.Drawing.Point(8, 192)
+        self._labelChoice.Name = "labelChoice"
+        self._labelChoice.Size = System.Drawing.Size(420, 40)
+        self._labelChoice.Text = Trans(141)
+        self._labelChoice.Tag = "Label"
+        #
+        # radioChoiceSkip (no user choice allowed)
+        #
+        self._radioChoiceSkip.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._radioChoiceSkip.Location = System.Drawing.Point(16, 16)
+        self._radioChoiceSkip.Name = "radioChoiceSkip"
+        self._radioChoiceSkip.Size = System.Drawing.Size(200, 24)
+        self._radioChoiceSkip.Text = Trans(45)
+        self._radioChoiceSkip.UseVisualStyleBackColor = True
+        #
+        # radioChoiceUser (no user choice allowed)
+        #
+        self._radioChoiceUser.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._radioChoiceUser.Location = System.Drawing.Point(220, 16)
+        self._radioChoiceUser.Name = "radioChoiceUser"
+        self._radioChoiceUser.Size = System.Drawing.Size(200, 24)
+        self._radioChoiceUser.Text = Trans(46)
+        self._radioChoiceUser.UseVisualStyleBackColor = True
+        if AllowUserChoice:
+            self._radioChoiceUser.Checked = True
+            self._radioChoiceSkip.Checked = False
+        else:
+            self._radioChoiceSkip.Checked = True
+            self._radioChoiceUser.Checked = False
         #
         # AlwaysChooseSerie
         #
-        self._AlwaysChooseSerie.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._AlwaysChooseSerie.Location = System.Drawing.Point(320, 282)
+        self._AlwaysChooseSerie.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._AlwaysChooseSerie.Location = System.Drawing.Point(8, 128)
         self._AlwaysChooseSerie.Name = "AlwaysChooseSerie"
-        self._AlwaysChooseSerie.Size = System.Drawing.Size(180, 20)
+        self._AlwaysChooseSerie.Size = System.Drawing.Size(320, 20)
         self._AlwaysChooseSerie.TabIndex = 28
         self._AlwaysChooseSerie.Text = Trans(151)
         self._AlwaysChooseSerie.UseVisualStyleBackColor = True
@@ -3029,50 +2770,50 @@ class BDConfigForm(Form):
         #
         # One Shot in Format
         #
-        self._OneShotFormat.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._OneShotFormat.Location = System.Drawing.Point(16, 331)
+        self._OneShotFormat.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._OneShotFormat.Location = System.Drawing.Point(268, 8)
         self._OneShotFormat.Name = "OneShotFormat"
-        self._OneShotFormat.Size = System.Drawing.Size(250, 20)
+        self._OneShotFormat.Size = System.Drawing.Size(350, 24)
         self._OneShotFormat.TabIndex = 29
         self._OneShotFormat.Text = Trans(150)
         self._OneShotFormat.UseVisualStyleBackColor = True
         self._OneShotFormat.CheckState = if_else(ONESHOTFORMAT, CheckState.Checked, CheckState.Unchecked)
         #
-        # TIMEOUT Label4
+        # TIMEOUT Label
         #
-        self._label4.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._label4.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._label4.Location = System.Drawing.Point(320, 324)
-        self._label4.Name = "label4"
-        self._label4.Size = System.Drawing.Size(160, 23)
-        self._label4.TabIndex = 99
-        self._label4.Text = Trans(128)
+        self._labelTIMEOUT.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelTIMEOUT.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
+        self._labelTIMEOUT.Location = System.Drawing.Point(320, 274)
+        self._labelTIMEOUT.Name = "labelTIMEOUT"
+        self._labelTIMEOUT.Size = System.Drawing.Size(200, 23)
+        self._labelTIMEOUT.TabIndex = 99
+        self._labelTIMEOUT.Text = Trans(128)
         #
         # TIMEOUT
         #
-        self._TIMEOUT.Location = System.Drawing.Point(435, 324)
+        self._TIMEOUT.Location = System.Drawing.Point(550, 272)
         self._TIMEOUT.Name = "TIMEOUT"
-        self._TIMEOUT.Size = System.Drawing.Size(50, 21)
+        self._TIMEOUT.Size = System.Drawing.Size(40, 20)
         self._TIMEOUT.TabIndex = 29
         self._TIMEOUT.TextAlign = HorizontalAlignment.Center
         self._TIMEOUT.MaxLength = 4
         self._TIMEOUT.Text = TIMEOUT
         #
-        # TIMEOUTS Label6
+        # TIMEOUTS Label
         #
-        self._label6.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._label6.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
-        self._label6.Location = System.Drawing.Point(8, 236)
-        self._label6.Name = "label6"
-        self._label6.Size = System.Drawing.Size(160, 23)
-        self._label6.TabIndex = 99
-        self._label6.Text = Trans(129)
+        self._labelTIMEOUTS.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelTIMEOUTS.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft
+        self._labelTIMEOUTS.Location = System.Drawing.Point(8, 246)
+        self._labelTIMEOUTS.Name = "labelTIMEOUTS"
+        self._labelTIMEOUTS.Size = System.Drawing.Size(260, 23)
+        self._labelTIMEOUTS.TabIndex = 99
+        self._labelTIMEOUTS.Text = Trans(129)
         #
         # TIMEOUTS
         #
-        self._TIMEOUTS.Location = System.Drawing.Point(180, 232)
+        self._TIMEOUTS.Location = System.Drawing.Point(268, 244)
         self._TIMEOUTS.Name = "TIMEOUTS"
-        self._TIMEOUTS.Size = System.Drawing.Size(50, 21)
+        self._TIMEOUTS.Size = System.Drawing.Size(40, 20)
         self._TIMEOUTS.TabIndex = 30
         self._TIMEOUTS.TextAlign = HorizontalAlignment.Center
         self._TIMEOUTS.MaxLength = 3
@@ -3080,10 +2821,10 @@ class BDConfigForm(Form):
         #
         # DBGONOFF
         #
-        self._DBGONOFF.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._DBGONOFF.Location = System.Drawing.Point(8, 80)
+        self._DBGONOFF.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._DBGONOFF.Location = System.Drawing.Point(8, 36)
         self._DBGONOFF.Name = "DBGONOFF"
-        self._DBGONOFF.Size = System.Drawing.Size(200, 25)
+        self._DBGONOFF.Size = System.Drawing.Size(200, 20)
         self._DBGONOFF.TabIndex = 3
         self._DBGONOFF.Text = Trans(68)
         self._DBGONOFF.UseVisualStyleBackColor = True
@@ -3091,10 +2832,10 @@ class BDConfigForm(Form):
         #
         # SHOWDBGLOG
         #
-        self._SHOWDBGLOG.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._SHOWDBGLOG.Location = System.Drawing.Point(8, 40)
+        self._SHOWDBGLOG.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._SHOWDBGLOG.Location = System.Drawing.Point(8, 64)
         self._SHOWDBGLOG.Name = "SHOWDBGLOG"
-        self._SHOWDBGLOG.Size = System.Drawing.Size(300, 25)
+        self._SHOWDBGLOG.Size = System.Drawing.Size(300, 20)
         self._SHOWDBGLOG.TabIndex = 2
         self._SHOWDBGLOG.Text = Trans(67)
         self._SHOWDBGLOG.UseVisualStyleBackColor = True
@@ -3102,19 +2843,30 @@ class BDConfigForm(Form):
         #
         # SHOWRENLOG
         #
-        self._SHOWRENLOG.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._SHOWRENLOG.Location = System.Drawing.Point(8, 0)
+        self._SHOWRENLOG.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._SHOWRENLOG.Location = System.Drawing.Point(8, 8)
         self._SHOWRENLOG.Name = "SHOWRENLOG"
-        self._SHOWRENLOG.Size = System.Drawing.Size(300, 25)
+        self._SHOWRENLOG.Size = System.Drawing.Size(300, 20)
         self._SHOWRENLOG.TabIndex = 1
         self._SHOWRENLOG.Text = Trans(66)
         self._SHOWRENLOG.UseVisualStyleBackColor = True
         self._SHOWRENLOG.CheckState = if_else(SHOWRENLOG, CheckState.Checked, CheckState.Unchecked)
         #
+        # labelLanguage
+        #
+        self._labelLanguage.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._labelLanguage.Location = System.Drawing.Point(8, 8)
+        self._labelLanguage.Name = "labelLanguage"
+        self._labelLanguage.Size = System.Drawing.Size(120, 24)
+        self._labelLanguage.TabIndex = 31
+        self._labelLanguage.Text = Trans(112)
+        self._labelLanguage.Tag = "Label"
+        self._labelLanguage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
+        #
         # radioENG
         #
-        self._radioENG.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._radioENG.Location = System.Drawing.Point(8, 200)
+        self._radioENG.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._radioENG.Location = System.Drawing.Point(128, 8)
         self._radioENG.Name = "radioENG"
         self._radioENG.Size = System.Drawing.Size(104, 24)
         self._radioENG.TabIndex = 6
@@ -3124,8 +2876,8 @@ class BDConfigForm(Form):
         # radioFRE
         #
         self._radioFRE.Checked = True
-        self._radioFRE.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-        self._radioFRE.Location = System.Drawing.Point(160, 200)
+        self._radioFRE.Font = System.Drawing.Font("Microsoft Sans Serif", 8.25, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0)
+        self._radioFRE.Location = System.Drawing.Point(240, 8)
         self._radioFRE.Name = "radioFRE"
         self._radioFRE.Size = System.Drawing.Size(104, 24)
         self._radioFRE.TabIndex = 7
@@ -3143,7 +2895,7 @@ class BDConfigForm(Form):
         #
         pImage = (__file__[:-len('BedethequeScraper2.py')] + "BD2.png")
         self._PB1.Image = System.Drawing.Bitmap(pImage)
-        self._PB1.Location = System.Drawing.Point(420, 4)
+        self._PB1.Location = System.Drawing.Point(520, 4)
         self._PB1.Name = "PB1"
         self._PB1.Size = System.Drawing.Size(72, 64)
         self._PB1.TabIndex = 35
@@ -3153,14 +2905,19 @@ class BDConfigForm(Form):
         #
         # ConfigForm
         #
-        self.ClientSize = System.Drawing.Size(512, 412)
+        self.ClientSize = System.Drawing.Size(612, 412)
         self.Controls.Add(self._TabData)
+        self.Controls.Add(self._labelVersion)
+        self.Controls.Add(self._CancelButton)
+        self.Controls.Add(self._OKButton)
 
         self._TabData.ResumeLayout(False)
         self._tabPage1.ResumeLayout(False)
         self._tabPage1.PerformLayout()
         self._tabPage2.ResumeLayout(False)
         self._tabPage2.PerformLayout()
+        self._tabPage3.ResumeLayout(False)
+        self._tabPage3.PerformLayout()
         self.AcceptButton = self._OKButton
         self.CancelButton = self._CancelButton
         self.KeyPreview = True
@@ -3174,52 +2931,43 @@ class BDConfigForm(Form):
     def button_Click(self, sender, e):
 
         global SHOWRENLOG, SHOWDBGLOG, DBGONOFF, DBGLOGMAX, RENLOGMAX, LANGENFR, aWord, ONESHOTFORMAT
-        global TBTags, CBCover, CBStatus, CBGenre, CBNotes, CBWeb, CBCount, CBSynopsys, CBImprint, CBLetterer, CBPrinted, CBRating, CBISBN, CBDefault, CBRescrape, CBStop, PopUpEditionForm, SerieResumeEverywhere
-        global CBLanguage, CBEditor, CBFormat, CBColorist, CBPenciller, CBWriter, CBTitle, CBSeries, ARTICLES, SUBPATT, COUNTOF, CBCouverture, COUNTFINIE, TITLEIT, TIMEOUT, TIMEOUTS, TIMEPOPUP, FORMATARTICLES, PadNumber, AlwaysChooseSerie
+        global TBTags, CBCover, CBStatus, CBGenre, CBNotes, CBWeb, CBCount, CBSynopsys, CBImprint, CBLetterer, CBPrinted, CBRating, CBISBN, CBDefault, CBRescrape, AllowUserChoice, PopUpEditionForm, SerieResumeEverywhere
+        global CBLanguage, CBEditor, CBFormat, CBColorist, CBPenciller, CBWriter, CBTitle, CBSeries, ARTICLES, SUBPATT, COUNTOF, CBCouverture, COUNTFINIE, TITLEIT, TIMEOUT, TIMEOUTS, TIMEPOPUP, FORMATARTICLES, PadNumber, AlwaysChooseSerie, ShortWebLink
 
         if sender.Name.CompareTo(self._OKButton.Name) == 0:
             SHOWRENLOG = if_else(self._SHOWRENLOG.CheckState == CheckState.Checked, True, False)
             SHOWDBGLOG = if_else(self._SHOWDBGLOG.CheckState == CheckState.Checked, True, False)
             DBGONOFF = if_else(self._DBGONOFF.CheckState == CheckState.Checked, True, False)
-            DBGLOGMAX = int(self._DBGLOGMAX.Text)
-            RENLOGMAX = int(self._RENLOGMAX.Text)
+            DBGLOGMAX = int(self._DBGLOGMAX.Text)*1024*1024
+            RENLOGMAX = int(self._RENLOGMAX.Text)*1024*1024
             LANGENFR = if_else(self._radioENG.Checked,"EN", "FR")
             TBTags = self._TBTags.Text
-            CBCover = if_else(self._CBCover.CheckState == CheckState.Checked, True, False)
-            CBStatus = if_else(self._CBStatus.CheckState == CheckState.Checked, True, False)
-            CBGenre = if_else(self._CBGenre.CheckState == CheckState.Checked, True, False)
-            CBNotes = if_else(self._CBNotes.CheckState == CheckState.Checked, True, False)            
-            if self._CBWeb.CheckState == CheckState.Checked:
-                CBWeb = True
-            elif self._CBWeb.CheckState == CheckState.Unchecked:
-                CBWeb = False
-            elif self._CBWeb.CheckState == CheckState.Indeterminate:
-                CBWeb = "2"
-
-            CBCount = if_else(self._CBCount.CheckState == CheckState.Checked, True, False)
-            CBSynopsys = if_else(self._CBSynopsys.CheckState == CheckState.Checked, True, False)
-            CBImprint = if_else(self._CBImprint.CheckState == CheckState.Checked, True, False)
-            CBLetterer = if_else(self._CBLetterer.CheckState == CheckState.Checked, True, False)
-            CBPrinted = if_else(self._CBPrinted.CheckState == CheckState.Checked, True, False)
-            CBRating = if_else(self._CBRating.CheckState == CheckState.Checked, True, False)
-            CBISBN = if_else(self._CBISBN.CheckState == CheckState.Checked, True, False)
-            CBLanguage = if_else(self._CBLanguage.CheckState == CheckState.Checked, True, False)
-            CBEditor = if_else(self._CBEditor.CheckState == CheckState.Checked, True, False)
-            CBFormat = if_else(self._CBFormat.CheckState == CheckState.Checked, if_else(self._OneShotFormat.CheckState == CheckState.Checked, False, True), False)
-            CBColorist = if_else(self._CBColorist.CheckState == CheckState.Checked, True, False)
-            CBPenciller = if_else(self._CBPenciller.CheckState == CheckState.Checked, True, False)
-            CBWriter = if_else(self._CBWriter.CheckState == CheckState.Checked, True, False)
-            CBTitle = if_else(self._CBTitle.CheckState == CheckState.Checked, True, False)
-            CBSeries = if_else(self._CBSeries.CheckState == CheckState.Checked, True, False)
+            ShortWebLink = if_else(self._ShortWebLink.CheckState == CheckState.Checked, True, False)
+            CBCover = if_else(self._scrapedData['Cover']['state'] == CheckState.Checked, True, False)
+            CBCouverture = if_else(self._scrapedData['CoverArtist']['state'] == CheckState.Checked, True, False)
+            CBStatus = if_else(self._scrapedData['SerieStatus']['state'] == CheckState.Checked, True, False)
+            CBGenre = if_else(self._scrapedData['Genre']['state'] == CheckState.Checked, True, False)
+            CBNotes = if_else(self._scrapedData['Notes']['state'] == CheckState.Checked, True, False)
+            CBWeb = if_else(self._scrapedData['Web']['state'] == CheckState.Checked, True, False)
+            CBCount = if_else(self._scrapedData['Count']['state'] == CheckState.Checked, True, False)
+            CBSynopsys = if_else(self._scrapedData['Synopsys']['state'] == CheckState.Checked, True, False)
+            CBImprint = if_else(self._scrapedData['Imprint']['state'] == CheckState.Checked, True, False)
+            CBLetterer = if_else(self._scrapedData['Web']['state'] == CheckState.Checked, True, False)
+            CBPrinted = if_else(self._scrapedData['Printed']['state'] == CheckState.Checked, True, False)
+            CBRating = if_else(self._scrapedData['Rating']['state'] == CheckState.Checked, True, False)
+            CBISBN = if_else(self._scrapedData['ISBN']['state'] == CheckState.Checked, True, False)
+            CBLanguage = if_else(self._scrapedData['Language']['state'] == CheckState.Checked, True, False)
+            CBEditor = if_else(self._scrapedData['Publisher']['state'] == CheckState.Checked, True, False)
+            CBFormat = if_else(self._scrapedData['SerieStatus']['state'] == CheckState.Checked, if_else(self._OneShotFormat.CheckState == CheckState.Checked, False, True), False)
+            CBColorist = if_else(self._scrapedData['Colorist']['state'] == CheckState.Checked, True, False)
+            CBPenciller = if_else(self._scrapedData['Penciller']['state'] == CheckState.Checked, True, False)
+            CBWriter = if_else(self._scrapedData['Writer']['state'] == CheckState.Checked, True, False)
+            CBTitle = if_else(self._scrapedData['Title']['state'] == CheckState.Checked, True, False)
+            CBSeries = if_else(self._scrapedData['Series']['state'] == CheckState.Checked, True, False)
             CBDefault = if_else(self._CBDefault.CheckState == CheckState.Checked, True, False)
             CBRescrape = if_else(self._CBRescrape.CheckState == CheckState.Checked, True, False)
-            if self._CBStop.CheckState == CheckState.Checked:
-                CBStop = True
-            elif self._CBStop.CheckState == CheckState.Unchecked:
-                CBStop = False
-            elif self._CBStop.CheckState == CheckState.Indeterminate:
-                CBStop = "2"
-            
+            AllowUserChoice = if_else(self._radioChoiceUser.Checked, True, False)
+
             ARTICLES = self._ARTICLES.Text
             SUBPATT = self._SUBPATT.Text
             COUNTOF = if_else(self._COUNTOF.CheckState == CheckState.Checked, True, False)
@@ -3230,7 +2978,7 @@ class BDConfigForm(Form):
             PopUpEditionForm = if_else(self._PopUpEditionForm.CheckState == CheckState.Checked, False, True)
             SerieResumeEverywhere = if_else(self._SerieResumeEverywhere.CheckState == CheckState.Checked, False, True)
             AlwaysChooseSerie = if_else(self._AlwaysChooseSerie.CheckState == CheckState.Checked, True, False)
-#modif kiwi
+
             try:
                 if int(self._TIMEOUT.Text) > 0:
                     TIMEOUT = self._TIMEOUT.Text
@@ -3266,16 +3014,27 @@ class BDConfigForm(Form):
             aWord = Translate()
             log_BD(TIMEOUTS,"",1)
 
-        if sender.Name.CompareTo(self._ButtonReset.Name) == 0:
-            for CBControl in self._tabPage2.Controls:
-                try:
-                    if CBControl.CheckState == CheckState.Checked:
-                        CBControl.CheckState = CheckState.Unchecked
-                    else:
-                        CBControl.CheckState = CheckState.Checked
-                except:
-                    pass
-            self._TBTags.Text = ""
+        elif sender.Name.CompareTo(self._ButtonCheckNone.Name) == 0:
+            for index in range(self._ScrapedDataCheckedListBox.Items.Count):
+                self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Unchecked)
+                if index == self._scrapedData.keys().index('Web'):
+                    self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Unchecked)
+        elif sender.Name.CompareTo(self._ButtonCheckAll.Name) == 0:
+            for index in range(self._ScrapedDataCheckedListBox.Items.Count):
+                self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Checked)
+                if index == self._scrapedData.keys().index('Web'):
+                    self._ScrapedDataCheckedListBox.SetItemCheckState(index, CheckState.Checked)
+
+    def ScrapedDataCheckedListBox_CheckItem(self, sender, e):
+        # Override behavior for some checkbox for example if we want a threestate checkbox
+        # if e.Index == self._scrapedData.keys().index('Web'):
+            # if e.CurrentValue == CheckState.Checked:
+            #     e.NewValue = CheckState.Indeterminate
+            # elif e.CurrentValue == CheckState.Indeterminate:
+            #     e.NewValue = CheckState.Unchecked
+            # else:
+            #     e.NewValue = CheckState.Checked
+        self._scrapedData[self._scrapedData.keys()[e.Index]]['state'] = e.NewValue
 
 def Translate():
 
@@ -3283,11 +3042,11 @@ def Translate():
 
     path = (__file__[:-len('BedethequeScraper2.py')])
     
-    if not File.Exists(path + "\BDTranslations.Config"):                
+    if not File.Exists(path + "\BDTranslations.Config"):
         log_BD("File BDTranslations.Config missing !", "Error!", 1)
         sys.exit(0)
 
-    try:    
+    try:
         TransSettings = AppSettings()
         TransSettings.Load(path + "\BDTranslations.Config")
     except Exception as e:
@@ -3295,13 +3054,13 @@ def Translate():
         sys.exit(0)
 
     aWord = list()
-    
+
     for i in range (1, 200):
         try:
             aWord.append(TransSettings.Get('T' + '%04d' % i + '/' + LANGENFR))
         except:
-            exit    
-    
+            exit
+
     return aWord
 
 def Trans(nWord):
@@ -3312,10 +3071,10 @@ def Trans(nWord):
 
 def cleanARTICLES(s):
 
-    ns = re.search(r"^(" + ARTICLES.replace(',','|') + ")\s*(?<=['\s])((?=[^\/\r\n\(\:]*(?:\s[-:]\s))[^\-\:\r\n]*|(?=[^\/\r\n\(\:]*(?:\s[–:]\s))[^\–\:\r\n]*|[^\/\r\n\(\:]*)", s, re.IGNORECASE)
+    ns = re.search(r"^(" + ARTICLES.replace(',','|') + ")\s*(?<=['\s])((?=[^/\r\n\(:]*(?:\s[-:]\s))[^-:\r\n]*|(?=[^/\r\n\(:]*(?:\s[–:]\s))[^\–:\r\n]*|[^/\r\n\(:]*)", s, re.IGNORECASE)
     if ns:
         s = ns.group(2).strip()
-    ns2 = re.search(r"^[#]*(.(?=[^\/\r\n\(\:]*(?:\s[-:!]\s))[^\-\:\r\n]*|.(?=[^\/\r\n\(\:!]*(?:\s[–:]\s))[^\–\:\r\n]*|.[^\/\r\n\(\:\,!]*)", s, re.IGNORECASE)
+    ns2 = re.search(r"^[#]*(.(?=[^/\r\n\(:]*(?:\s[-:!]\s))[^-:\r\n]*|.(?=[^/\r\n\(:!]*(?:\s[–:]\s))[^\–:\r\n]*|.[^/\r\n\(:\,!]*)", s, re.IGNORECASE)
     if ns2:
         s = ns2.group(1).strip()
 
@@ -3323,19 +3082,18 @@ def cleanARTICLES(s):
 
 def formatARTICLES(s):
 
-    ns = re.sub(r"^(" + ARTICLES.replace(',','|') + ")\s*(?<=['\s])((?=[^(]*(?:\s[-:]\s))[^\-\:\r\n]*|(?=[^(]*(?:\s[–:]\s))[^\–\:\r\n]*|[^\(\/\r\n]*)(?!\(|\/|\-|\–|\:)\s*([^\r\n]*)", r"\2 (\1) \3", s, re.IGNORECASE)
+    ns = re.sub(r"^(" + ARTICLES.replace(',','|') + ")\s*(?<=['\s])((?=[^(]*(?:\s[-:]\s))[^-:\r\n]*|(?=[^(]*(?:\s[–:]\s))[^\–:\r\n]*|[^\(/\r\n]*)(?!\(|/|-|\–|:)\s*([^\r\n]*)", r"\2 (\1) \3", s, re.IGNORECASE)
     if ns:
         s = Capitalize(ns.strip())
 
     return s
 
 def titlize(s, formatArticles = False):
-    
+
     if formatArticles and FORMATARTICLES:
         s = formatARTICLES(s)
-    
+
     if TITLEIT:
-        #CharList = '[\.\?\!\(\[]\s\"\'\[\]'        
         NewString = ""
         Ucase = False
         for i in range(len(s.strip())):
@@ -3343,55 +3101,52 @@ def titlize(s, formatArticles = False):
                 NewString += s[i:i + 1].upper()
             else:
                 NewString += s[i:i + 1]
-                
-            if not (s[i:i + 1]).isalnum() and s[i:i + 2].lower() != "'s": # in CharList:
+
+            if not (s[i:i + 1]).isalnum() and s[i:i + 2].lower() != "'s":
                 Ucase = True
-            else:                
+            else:
                 Ucase = False
         test = s.title()
-        return NewString        
+        return NewString
     else:
         return s
 
 def Capitalize(s):
-    
+
     ns = s[0:1].upper() + s[1:]
     return ns
 
 class FormType():
     SERIE = 1
     ALBUM = 2
-    EDITION = 3    
+    EDITION = 3
 
 class SeriesForm(Form):
-    
+
     def __init__(self, serie, listItems, formType = FormType.SERIE):
-        
+
         self.List = listItems
         self.list_filtered_index = []
         self.formType = formType
         self.InitializeComponent(serie)
-    
+
     def InitializeComponent(self, serie):
 
         global TimerExpired
-        
+
         self.Load += self.MainForm_Load
         self._ListSeries = System.Windows.Forms.ListBox()
         self._CancelButton = System.Windows.Forms.Button()
         self._OKButton = System.Windows.Forms.Button()
         self._ClearButton = System.Windows.Forms.Button()
-        #self._SearchSeries = System.Windows.Forms.TextBox()
-        #self._labelSearch = System.Windows.Forms.Label()
-        if CBStop == "2":
+
+        if AllowUserChoice and TIMEPOPUP != "0":
             TimerExpired = False
             self._timer1 = System.Windows.Forms.Timer()
-#modif kiwi
             self._timer1.Interval = int(TIMEPOPUP) * 1000
             self._timer1.Enabled = True
             self._timer1.Tick += self.CloseForm
-        
-        #self.SuspendLayout()
+
         # 
         # ListSeries
         # 
@@ -3404,7 +3159,7 @@ class SeriesForm(Form):
         self._ListSeries.Size = System.Drawing.Size(374, 258)
         self._ListSeries.Sorted = True
         self._ListSeries.TabIndex = 3
-        self._ListSeries.DoubleClick += self.DoubleClick        
+        self._ListSeries.DoubleClick += self.DoubleClick
         # 
         # CancelButton
         # 
@@ -3459,20 +3214,19 @@ class SeriesForm(Form):
         self._ClearButton.UseVisualStyleBackColor = True
         self._ClearButton.Click += self.ClearButton_Click
             
-        self.ClientSize = System.Drawing.Size(390, 325)        
+        self.ClientSize = System.Drawing.Size(390, 325)
         self.MinimumSize = System.Drawing.Size(180, 180)
         self.Controls.Add(self._Filter)
         self.Controls.Add(self._ListSeries)
         self.Controls.Add(self._OKButton)
         self.Controls.Add(self._CancelButton)
         self.Controls.Add(self._ClearButton)
-        #self.Controls.Add(self._timer1)
         self.MaximizeBox = False
         self.MinimizeBox = False
         self.Name = "SeriesForm"
         self.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide
         self.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
-        
+
         frmTitle = ""
         if self.formType == FormType.SERIE: 
             frmTitle = Trans(132) + serie
@@ -3485,24 +3239,22 @@ class SeriesForm(Form):
         self.AcceptButton = self._OKButton
         self.CancelButton = self._CancelButton
         self.KeyPreview = True
-        
+
         self.fillList()
 
         # Adjust DPI scaling in this form
         HighDpiHelper.AdjustControlImagesDpiScale(self)
 
-        #self.ResumeLayout(False)        
-        #self.PerformLayout()
-        if CBStop == "2":
+        if AllowUserChoice and TIMEPOPUP != "0":
             self._timer1.Start()
 
     def fillList(self, ):
         self._ListSeries.Items.Clear()
         del self.list_filtered_index[:]
         filter = self._Filter.Text.strip().lower()
-        for x in range(len(self.List)):            
+        for x in range(len(self.List)):
             if self.List[x]:
-                title = ""        
+                title = ""
                 if self.formType == FormType.EDITION: 
                     title = self.List[x][1].Title
                 else: 
@@ -3513,17 +3265,14 @@ class SeriesForm(Form):
                     continue
                 self._ListSeries.Items.Add(display)
                 self.list_filtered_index.append(x)
-                # self._ListSeries.Items.Add("(" + self.List[x][2] + ")- " + self.List[x][1] + if_else(self.List[x][0], "   (", "") + self.List[x][0] + if_else(self.List[x][0], ")", ""))
-                #self._ListSeries.Items.Add("(" + ListSeries[x][2] + ")- " + ListSeries[x][1].decode('utf-8') + if_else(ListSeries[x][0], "   (", "") + ListSeries[x][0] + if_else(ListSeries[x][0], ")", ""))
-            #self._ListSeries.Items.soSort()
 
     def onTextChanged(self, sender, e):
         self.fillList()
 
     def button_Click(self, sender, e):
-    
+
         global NewLink, NewSeries
-        
+
         sel = self.list_filtered_index[self._ListSeries.SelectedIndex]
         if sender.Name.CompareTo(self._OKButton.Name) == 0 and self.List[sel][1]:
             NewLink = self.List[sel][0]
@@ -3538,16 +3287,16 @@ class SeriesForm(Form):
     def CloseForm(self, sender, e):
 
         global TimerExpired
-    
+
         if DBGONOFF:print "Timer Expired"
         TimerExpired = True
         self._timer1.Stop()
         self.Hide()
-    
+
     def DoubleClick(self, sender, e):
-                
+
         global NewLink, NewSeries
-        
+
         title = ""
         link = ""
         sel = self.list_filtered_index[self._ListSeries.SelectedIndex]
@@ -3556,31 +3305,27 @@ class SeriesForm(Form):
             link = "https://www.bedetheque.com/" + self.List[sel][0]
         elif self.formType == FormType.EDITION: 
             title = self.List[sel][1].Title + " (" + self.List[sel][1].A + ")"
-            link = self.List[sel][1].URL# or self.List[sel][1].Couv
-        elif self.formType == FormType.ALBUM: 
+            link = self.List[sel][1].URL
+        elif self.formType == FormType.ALBUM:
             title = self.List[sel][1]
             link = self.List[sel][0]
-                    
+
         if title:
             NewLink = link
             NewSeries = self.List[sel][1]
             Start(NewLink)
-            #NewSeries = ListSeries[sel][1]
-            #self.Hide()
-            #self.DialogResult = DialogResult.OK
-            #return
-    
+
     def MainForm_Load(self, sender, e):
         self.Left += 365
-        
+
 #@Key Bedetheque2
 #@Hook ConfigScript
 #@Name Configurer BD2
 def ConfigureBD2Quick():
-    
+
     if not LoadSetting():
         return
-    
+
     config = BDConfigForm()
     result = config.ShowDialog()
 
@@ -3619,12 +3364,8 @@ def QuickScrapeBD2(books, book = "", cLink = False):
     if not cLink:
         if not LoadSetting():
             return False
-    
+
     RenameSeries = False
-    
-    #FICHE_SERIE_PATTERN = r'<a\sclass=\"back\"\shref=\"(.*?)\">'
-    # FICHE_SERIE_PATTERN = r'>album</a>.*?href=\"(.*)\">s.rie\s?:'
-    # FICHE_SERIE = re.compile(FICHE_SERIE_PATTERN, re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
     if not books:
         Result = MessageBox.Show(ComicRack.MainWindow, Trans(1),Trans(2), MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
@@ -3634,11 +3375,11 @@ def QuickScrapeBD2(books, book = "", cLink = False):
 
     if not cLink:
         nRenamed = 0
-        nIgnored = 0    
+        nIgnored = 0
     cError = False
     MyBooks = []
-    
-    try:    
+
+    try:
 
         if books:
             if cLink:
@@ -3648,21 +3389,18 @@ def QuickScrapeBD2(books, book = "", cLink = False):
                 f = ProgressBarDialog(books.Count)
                 if books.Count > 1:
                     f.Show(ComicRack.MainWindow)
-            
-            # if MyBooks.Count <> 1:
-                # return False
-                
+
             log_BD(Trans(7) + str(MyBooks.Count) +  Trans(8), "\n============ " + str(datetime.now().strftime("%A %d %B %Y %H:%M:%S")) + " ===========", 0)
-                    
+
             for MyBook in MyBooks:
-        
-                if cLink:                    
-                    Numero = ""            
+
+                if cLink:
+                    Numero = ""
                     serieUrl = cLink
                     LinkBD2 = serieUrl
-                    
+
                 else:
-                    
+
                     if MyBook.Number:
                         dlgNumber = MyBook.Number
                         Shadow2 = False
@@ -3682,12 +3420,12 @@ def QuickScrapeBD2(books, book = "", cLink = False):
                         dlgAltNumber = MyBook.AlternateNumber
 
                     albumNum = dlgNumber
-                    mPos = re.search(r'([.|,|\\|\/|-])', dlgNumber)
+                    mPos = re.search(r'([.,\\/-])', dlgNumber)
 
                     if not isnumeric(dlgNumber):
                         albumNum = dlgNumber
                         AlbumNumNum = False
-                    elif isnumeric(dlgNumber) and not re.search(r'[.|,|\\|\/|-]', dlgNumber):
+                    elif isnumeric(dlgNumber) and not re.search(r'[.,\\/-]', dlgNumber):
                         dlgNumber = str(int(dlgNumber))
                         albumNum = str(int(dlgNumber))
                         AlbumNumNum = True
@@ -3697,40 +3435,30 @@ def QuickScrapeBD2(books, book = "", cLink = False):
                         dlgAltNumber = dlgNumber[nPos:]
                         dlgNumber = albumNum
                         AlbumNumNum = True
-                    
-                    if not cLink:
-                        f.Update(dlgName + if_else(dlgNumber != "", " - " + dlgNumber, " ") + if_else(dlgAltNumber == '', '', ' AltNo.[' + dlgAltNumber + ']') + " - " + titlize(MyBook.Title), 1, MyBook)
-                        f.Refresh()    
-                    
+
+                    f.Update(dlgName + if_else(dlgNumber != "", " - " + dlgNumber, " ") + if_else(dlgAltNumber == '', '', ' AltNo.[' + dlgAltNumber + ']') + " - " + titlize(MyBook.Title), 1, MyBook)
+                    f.Refresh()
+
                     scrape = DirectScrape()
                     result = scrape.ShowDialog()
-                
+
                     if result == DialogResult.Cancel or (LinkBD2 == ""):
                         return False
-                
-                    if LinkBD2:                        
-                        serieUrl = GetFullURL(LinkBD2)
-                        
-                # try:
-                    # ficheUrl = _read_url(serieUrl, False)
-                # except:
-                    # return False
 
-                # fiche = FICHE_SERIE.search(ficheUrl)
+                    if LinkBD2:
+                        serieUrl = GetFullURL(LinkBD2)
 
                 if LinkBD2:
                     if DBGONOFF:print Trans(104), LinkBD2
 
-                # if fiche:    
-                    # RetVal = parseSerieInfo(MyBook, fiche.group(1), True)
                 RetVal = serieUrl
                 if "/serie-" in serieUrl or '/revue-' in serieUrl: 
                     serieUrl = serieUrl if "__10000.html" in serieUrl or '/revue-' in serieUrl else serieUrl.lower().replace(".html", u'__10000.html')                   
                     RetVal = parseSerieInfo(MyBook, serieUrl, True)
-                                                                        
+
                 if RetVal and not '/revue-' in serieUrl:
-                    if LinkBD2:                    
-                        RetVal = parseAlbumInfo(MyBook, RetVal, dlgNumber, True)                                                            
+                    if LinkBD2:
+                        RetVal = parseAlbumInfo(MyBook, RetVal, dlgNumber, True)
 
                 if RetVal:
                     if not cLink:
@@ -3746,12 +3474,12 @@ def QuickScrapeBD2(books, book = "", cLink = False):
             log_BD(Trans(15), "", 1)
             return False
 
-    except:        
+    except:
         cError = debuglog()
         try:
-            log_BD("   [" + serieUrl + "]", cError, 1)        
+            log_BD("   [" + serieUrl + "]", cError, 1)
         except:
-            log_BD("   [error]", cError, 1)        
+            log_BD("   [error]", cError, 1)
         if not cLink:
             f.Close()
         return False
@@ -3759,9 +3487,8 @@ def QuickScrapeBD2(books, book = "", cLink = False):
     finally:
         if not cLink:
             f.Update(Trans(16), 1, book)
-            f.Refresh()        
+            f.Refresh()
             f.Close()
-            #rdlg = MessageBox.Show(ComicRack.MainWindow, Trans(2),Trans(2), MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1)
 
             return False
 
@@ -3797,7 +3524,7 @@ class DirectScrape(Form):
         try:
             # BD
             self._LinkBD2 = System.Windows.Forms.TextBox()
-            self._label1 = System.Windows.Forms.Label()                        
+            self._labelPasteLink = System.Windows.Forms.Label()
             self._OKScrape = System.Windows.Forms.Button()
             self._CancScrape = System.Windows.Forms.Button()
             #
@@ -3810,15 +3537,15 @@ class DirectScrape(Form):
             self._LinkBD2.Text = ""
             self._LinkBD2.WordWrap = False
             #
-            # label1
+            # labelPasteLink
             #
-            self._label1.Font = System.Drawing.Font("Microsoft Sans Serif", 11.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
-            self._label1.Location = System.Drawing.Point(104, 8)
-            self._label1.Name = "label1"
-            self._label1.Size = System.Drawing.Size(450, 20)
-            self._label1.TabIndex = 99
-            self._label1.Text = Trans(102)
-            self._label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+            self._labelPasteLink.Font = System.Drawing.Font("Microsoft Sans Serif", 11.25, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0)
+            self._labelPasteLink.Location = System.Drawing.Point(104, 8)
+            self._labelPasteLink.Name = "labelPasteLink"
+            self._labelPasteLink.Size = System.Drawing.Size(450, 20)
+            self._labelPasteLink.TabIndex = 99
+            self._labelPasteLink.Text = Trans(102)
+            self._labelPasteLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
             #
             # OKScrape
             #
@@ -3853,8 +3580,8 @@ class DirectScrape(Form):
             self.ControlBox = False
             self.Controls.Add(self._CancScrape)
             self.Controls.Add(self._OKScrape)
-            self.Controls.Add(self._label1)
-            self.Controls.Add(self._LinkBD2)            
+            self.Controls.Add(self._labelPasteLink)
+            self.Controls.Add(self._LinkBD2)
             #
             self.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
             self.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
@@ -3880,20 +3607,15 @@ class DirectScrape(Form):
             global LinkBD2
 
             if not self._LinkBD2.Text:
-                self.Hide()                
+                self.Hide()
                 LinkBD2 = ""
-            #elif not re.search ('www.bedetheque.*?album', self._LinkBD2.Text):
-            #    self.Hide()
-            #    Result = MessageBox.Show(ComicRack.MainWindow, Trans(106), Trans(2), MessageBoxButtons.OK, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1)
-            #    LinkBD2 = ""
-            
             else:
                 LinkBD2 = self._LinkBD2.Text
 
 class HighDpiHelper:
     @staticmethod
     def AdjustControlImagesDpiScale(container):
-        
+
         dpiScale = HighDpiHelper.GetDpiScale(container)
         if HighDpiHelper.CloseToOne(dpiScale):
             return

--- a/src/BedethequeScraper2.py
+++ b/src/BedethequeScraper2.py
@@ -151,7 +151,7 @@ SERIE_HEADER2 = re.compile(SERIE_HEADER2_PATTERN, re.IGNORECASE | re.MULTILINE |
 
 # Info Serie for Quickscrape
 
-SERIE_QSERIE_PATTERN = r'<h1>\s*<a href="(https://www.bedetheque.com[^\.]+\.html)"\stitle="([^"]+)">'
+SERIE_QSERIE_PATTERN = r'<h1>\s*<a href="(https://www.bedetheque.com[^\.]+\.html)"\stitle="[^"]+">\s*([^<]+)\s*</a'
 
 # Info Album from Album
 INFO_SERIENAMENUMBER_ALBUM_PATTERN = r'<span\sclass="type">S.*?rie\s:\s</span>\s?(.*?)<.*?id="%s">.*?<div\sclass="titre">(?:(.*?)<.*?numa">(.*?)</span>\.?\s?)?(.*?)<'
@@ -2113,9 +2113,13 @@ def LoadSetting():
     if ONESHOTFORMAT and CBFormat:
         CBFormat = False
 
+    # Compatibility with old version
     if CBWeb == 2:
         CBWeb = True
         ShortWebLink = True
+
+    if AllowUserChoice == 2:
+        AllowUserChoice = True
 
     SaveSetting()
 

--- a/src/collections.py
+++ b/src/collections.py
@@ -1,4 +1,4 @@
-__all__ = ['deque', 'defaultdict', 'namedtuple']
+__all__ = ['Counter', 'deque', 'defaultdict', 'namedtuple', 'OrderedDict']
 # For bootstrapping reasons, the collection ABCs are defined in _abcoll.py.
 # They should however be considered an integral part of collections.py.
 from _abcoll import *
@@ -9,8 +9,232 @@ from _collections import deque, defaultdict
 from operator import itemgetter as _itemgetter
 from keyword import iskeyword as _iskeyword
 import sys as _sys
+import heapq as _heapq
+from itertools import repeat as _repeat, chain as _chain, starmap as _starmap
 
-def namedtuple(typename, field_names, verbose=False):
+try:
+    from thread import get_ident as _get_ident
+except ImportError:
+    from dummy_thread import get_ident as _get_ident
+
+
+################################################################################
+### OrderedDict
+################################################################################
+
+class OrderedDict(dict):
+    'Dictionary that remembers insertion order'
+    # An inherited dict maps keys to values.
+    # The inherited dict provides __getitem__, __len__, __contains__, and get.
+    # The remaining methods are order-aware.
+    # Big-O running times for all methods are the same as regular dictionaries.
+
+    # The internal self.__map dict maps keys to links in a doubly linked list.
+    # The circular doubly linked list starts and ends with a sentinel element.
+    # The sentinel element never gets deleted (this simplifies the algorithm).
+    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+
+    def __init__(self, *args, **kwds):
+        '''Initialize an ordered dictionary.  The signature is the same as
+        regular dictionaries, but keyword arguments are not recommended because
+        their insertion order is arbitrary.
+
+        '''
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__root
+        except AttributeError:
+            self.__root = root = []                     # sentinel node
+            root[:] = [root, root, None]
+            self.__map = {}
+        self.__update(*args, **kwds)
+
+    def __setitem__(self, key, value, PREV=0, NEXT=1, dict_setitem=dict.__setitem__):
+        'od.__setitem__(i, y) <==> od[i]=y'
+        # Setting a new item creates a new link at the end of the linked list,
+        # and the inherited dictionary is updated with the new key/value pair.
+        if key not in self:
+            root = self.__root
+            last = root[PREV]
+            last[NEXT] = root[PREV] = self.__map[key] = [last, root, key]
+        dict_setitem(self, key, value)
+
+    def __delitem__(self, key, PREV=0, NEXT=1, dict_delitem=dict.__delitem__):
+        'od.__delitem__(y) <==> del od[y]'
+        # Deleting an existing item uses self.__map to find the link which gets
+        # removed by updating the links in the predecessor and successor nodes.
+        dict_delitem(self, key)
+        link_prev, link_next, key = self.__map.pop(key)
+        link_prev[NEXT] = link_next
+        link_next[PREV] = link_prev
+
+    def __iter__(self):
+        'od.__iter__() <==> iter(od)'
+        # Traverse the linked list in order.
+        NEXT, KEY = 1, 2
+        root = self.__root
+        curr = root[NEXT]
+        while curr is not root:
+            yield curr[KEY]
+            curr = curr[NEXT]
+
+    def __reversed__(self):
+        'od.__reversed__() <==> reversed(od)'
+        # Traverse the linked list in reverse order.
+        PREV, KEY = 0, 2
+        root = self.__root
+        curr = root[PREV]
+        while curr is not root:
+            yield curr[KEY]
+            curr = curr[PREV]
+
+    def clear(self):
+        'od.clear() -> None.  Remove all items from od.'
+        for node in self.__map.itervalues():
+            del node[:]
+        root = self.__root
+        root[:] = [root, root, None]
+        self.__map.clear()
+        dict.clear(self)
+
+    # -- the following methods do not depend on the internal structure --
+
+    def keys(self):
+        'od.keys() -> list of keys in od'
+        return list(self)
+
+    def values(self):
+        'od.values() -> list of values in od'
+        return [self[key] for key in self]
+
+    def items(self):
+        'od.items() -> list of (key, value) pairs in od'
+        return [(key, self[key]) for key in self]
+
+    def iterkeys(self):
+        'od.iterkeys() -> an iterator over the keys in od'
+        return iter(self)
+
+    def itervalues(self):
+        'od.itervalues -> an iterator over the values in od'
+        for k in self:
+            yield self[k]
+
+    def iteritems(self):
+        'od.iteritems -> an iterator over the (key, value) pairs in od'
+        for k in self:
+            yield (k, self[k])
+
+    update = MutableMapping.update
+
+    __update = update # let subclasses override update without breaking __init__
+
+    __marker = object()
+
+    def pop(self, key, default=__marker):
+        '''od.pop(k[,d]) -> v, remove specified key and return the corresponding
+        value.  If key is not found, d is returned if given, otherwise KeyError
+        is raised.
+
+        '''
+        if key in self:
+            result = self[key]
+            del self[key]
+            return result
+        if default is self.__marker:
+            raise KeyError(key)
+        return default
+
+    def setdefault(self, key, default=None):
+        'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
+
+    def popitem(self, last=True):
+        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+        '''
+        if not self:
+            raise KeyError('dictionary is empty')
+        key = next(reversed(self) if last else iter(self))
+        value = self.pop(key)
+        return key, value
+
+    def __repr__(self, _repr_running={}):
+        'od.__repr__() <==> repr(od)'
+        call_key = id(self), _get_ident()
+        if call_key in _repr_running:
+            return '...'
+        _repr_running[call_key] = 1
+        try:
+            if not self:
+                return '%s()' % (self.__class__.__name__,)
+            return '%s(%r)' % (self.__class__.__name__, self.items())
+        finally:
+            del _repr_running[call_key]
+
+    def __reduce__(self):
+        'Return state information for pickling'
+        items = [[k, self[k]] for k in self]
+        inst_dict = vars(self).copy()
+        for k in vars(OrderedDict()):
+            inst_dict.pop(k, None)
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def copy(self):
+        'od.copy() -> a shallow copy of od'
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S.
+        If not specified, the value defaults to None.
+
+        '''
+        self = cls()
+        for key in iterable:
+            self[key] = value
+        return self
+
+    def __eq__(self, other):
+        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+        while comparison to a regular mapping is order-insensitive.
+
+        '''
+        if isinstance(other, OrderedDict):
+            return len(self)==len(other) and self.items() == other.items()
+        return dict.__eq__(self, other)
+
+    def __ne__(self, other):
+        'od.__ne__(y) <==> od!=y'
+        return not self == other
+
+    # -- the following methods support python 3.x style dictionary views --
+
+    def viewkeys(self):
+        "od.viewkeys() -> a set-like object providing a view on od's keys"
+        return KeysView(self)
+
+    def viewvalues(self):
+        "od.viewvalues() -> an object providing a view on od's values"
+        return ValuesView(self)
+
+    def viewitems(self):
+        "od.viewitems() -> a set-like object providing a view on od's items"
+        return ItemsView(self)
+
+
+################################################################################
+### namedtuple
+################################################################################
+
+def namedtuple(typename, field_names, verbose=False, rename=False):
     """Returns a new subclass of tuple with named fields.
 
     >>> Point = namedtuple('Point', 'x y')
@@ -39,6 +263,16 @@ def namedtuple(typename, field_names, verbose=False):
     if isinstance(field_names, basestring):
         field_names = field_names.replace(',', ' ').split() # names separated by whitespace and/or commas
     field_names = tuple(map(str, field_names))
+    if rename:
+        names = list(field_names)
+        seen = set()
+        for i, name in enumerate(names):
+            if (not all(c.isalnum() or c=='_' for c in name) or _iskeyword(name)
+                or not name or name[0].isdigit() or name.startswith('_')
+                or name in seen):
+                names[i] = '_%d' % i
+            seen.add(name)
+        field_names = tuple(names)
     for name in (typename,) + field_names:
         if not all(c.isalnum() or c=='_' for c in name):
             raise ValueError('Type names and field names can only contain alphanumeric characters and underscores: %r' % name)
@@ -48,7 +282,7 @@ def namedtuple(typename, field_names, verbose=False):
             raise ValueError('Type names and field names cannot start with a number: %r' % name)
     seen_names = set()
     for name in field_names:
-        if name.startswith('_'):
+        if name.startswith('_') and not rename:
             raise ValueError('Field names cannot start with an underscore: %r' % name)
         if name in seen_names:
             raise ValueError('Encountered duplicate field name: %r' % name)
@@ -58,12 +292,12 @@ def namedtuple(typename, field_names, verbose=False):
     numfields = len(field_names)
     argtxt = repr(field_names).replace("'", "")[1:-1]   # tuple repr without parens or quotes
     reprtxt = ', '.join('%s=%%r' % name for name in field_names)
-    dicttxt = ', '.join('%r: t[%d]' % (name, pos) for pos, name in enumerate(field_names))
     template = '''class %(typename)s(tuple):
         '%(typename)s(%(argtxt)s)' \n
         __slots__ = () \n
         _fields = %(field_names)r \n
         def __new__(_cls, %(argtxt)s):
+            'Create new instance of %(typename)s(%(argtxt)s)'
             return _tuple.__new__(_cls, (%(argtxt)s)) \n
         @classmethod
         def _make(cls, iterable, new=tuple.__new__, len=len):
@@ -73,10 +307,11 @@ def namedtuple(typename, field_names, verbose=False):
                 raise TypeError('Expected %(numfields)d arguments, got %%d' %% len(result))
             return result \n
         def __repr__(self):
+            'Return a nicely formatted representation string'
             return '%(typename)s(%(reprtxt)s)' %% self \n
-        def _asdict(t):
-            'Return a new dict which maps field names to their values'
-            return {%(dicttxt)s} \n
+        def _asdict(self):
+            'Return a new OrderedDict which maps field names to their values'
+            return OrderedDict(zip(self._fields, self)) \n
         def _replace(_self, **kwds):
             'Return a new %(typename)s object replacing specified fields with new values'
             result = _self._make(map(kwds.pop, %(field_names)r, _self))
@@ -84,16 +319,17 @@ def namedtuple(typename, field_names, verbose=False):
                 raise ValueError('Got unexpected field names: %%r' %% kwds.keys())
             return result \n
         def __getnewargs__(self):
+            'Return self as a plain tuple.  Used by copy and pickle.'
             return tuple(self) \n\n''' % locals()
     for i, name in enumerate(field_names):
-        template += '        %s = _property(_itemgetter(%d))\n' % (name, i)
+        template += "        %s = _property(_itemgetter(%d), doc='Alias for field number %d')\n" % (name, i, i)
     if verbose:
         print template
 
     # Execute the template string in a temporary namespace and
     # support tracing utilities by setting a value for frame.f_globals['__name__']
     namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename,
-                     _property=property, _tuple=tuple)
+                     OrderedDict=OrderedDict, _property=property, _tuple=tuple)
     try:
         exec template in namespace
     except SyntaxError, e:
@@ -102,15 +338,297 @@ def namedtuple(typename, field_names, verbose=False):
 
     # For pickling to work, the __module__ variable needs to be set to the frame
     # where the named tuple is created.  Bypass this step in enviroments where
-    # sys._getframe is not defined (Jython for example).
-    if hasattr(_sys, '_getframe'):
+    # sys._getframe is not defined (Jython for example) or sys._getframe is not
+    # defined for arguments greater than 0 (IronPython).
+    try:
         result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
+    except (AttributeError, ValueError):
+        pass
 
     return result
 
 
+########################################################################
+###  Counter
+########################################################################
 
+class Counter(dict):
+    '''Dict subclass for counting hashable items.  Sometimes called a bag
+    or multiset.  Elements are stored as dictionary keys and their counts
+    are stored as dictionary values.
 
+    >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
+
+    >>> c.most_common(3)                # three most common elements
+    [('a', 5), ('b', 4), ('c', 3)]
+    >>> sorted(c)                       # list all unique elements
+    ['a', 'b', 'c', 'd', 'e']
+    >>> ''.join(sorted(c.elements()))   # list elements with repetitions
+    'aaaaabbbbcccdde'
+    >>> sum(c.values())                 # total of all counts
+    15
+
+    >>> c['a']                          # count of letter 'a'
+    5
+    >>> for elem in 'shazam':           # update counts from an iterable
+    ...     c[elem] += 1                # by adding 1 to each element's count
+    >>> c['a']                          # now there are seven 'a'
+    7
+    >>> del c['b']                      # remove all 'b'
+    >>> c['b']                          # now there are zero 'b'
+    0
+
+    >>> d = Counter('simsalabim')       # make another counter
+    >>> c.update(d)                     # add in the second counter
+    >>> c['a']                          # now there are nine 'a'
+    9
+
+    >>> c.clear()                       # empty the counter
+    >>> c
+    Counter()
+
+    Note:  If a count is set to zero or reduced to zero, it will remain
+    in the counter until the entry is deleted or the counter is cleared:
+
+    >>> c = Counter('aaabbc')
+    >>> c['b'] -= 2                     # reduce the count of 'b' by two
+    >>> c.most_common()                 # 'b' is still in, but its count is zero
+    [('a', 3), ('c', 1), ('b', 0)]
+
+    '''
+    # References:
+    #   http://en.wikipedia.org/wiki/Multiset
+    #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
+    #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
+    #   http://code.activestate.com/recipes/259174/
+    #   Knuth, TAOCP Vol. II section 4.6.3
+
+    def __init__(self, iterable=None, **kwds):
+        '''Create a new, empty Counter object.  And if given, count elements
+        from an input iterable.  Or, initialize the count from another mapping
+        of elements to their counts.
+
+        >>> c = Counter()                           # a new, empty counter
+        >>> c = Counter('gallahad')                 # a new counter from an iterable
+        >>> c = Counter({'a': 4, 'b': 2})           # a new counter from a mapping
+        >>> c = Counter(a=4, b=2)                   # a new counter from keyword args
+
+        '''
+        super(Counter, self).__init__()
+        self.update(iterable, **kwds)
+
+    def __missing__(self, key):
+        'The count of elements not in the Counter is zero.'
+        # Needed so that self[missing_item] does not raise KeyError
+        return 0
+
+    def most_common(self, n=None):
+        '''List the n most common elements and their counts from the most
+        common to the least.  If n is None, then list all element counts.
+
+        >>> Counter('abcdeabcdabcaba').most_common(3)
+        [('a', 5), ('b', 4), ('c', 3)]
+
+        '''
+        # Emulate Bag.sortedByCount from Smalltalk
+        if n is None:
+            return sorted(self.iteritems(), key=_itemgetter(1), reverse=True)
+        return _heapq.nlargest(n, self.iteritems(), key=_itemgetter(1))
+
+    def elements(self):
+        '''Iterator over elements repeating each as many times as its count.
+
+        >>> c = Counter('ABCABC')
+        >>> sorted(c.elements())
+        ['A', 'A', 'B', 'B', 'C', 'C']
+
+        # Knuth's example for prime factors of 1836:  2**2 * 3**3 * 17**1
+        >>> prime_factors = Counter({2: 2, 3: 3, 17: 1})
+        >>> product = 1
+        >>> for factor in prime_factors.elements():     # loop over factors
+        ...     product *= factor                       # and multiply them
+        >>> product
+        1836
+
+        Note, if an element's count has been set to zero or is a negative
+        number, elements() will ignore it.
+
+        '''
+        # Emulate Bag.do from Smalltalk and Multiset.begin from C++.
+        return _chain.from_iterable(_starmap(_repeat, self.iteritems()))
+
+    # Override dict methods where necessary
+
+    @classmethod
+    def fromkeys(cls, iterable, v=None):
+        # There is no equivalent method for counters because setting v=1
+        # means that no element can have a count greater than one.
+        raise NotImplementedError(
+            'Counter.fromkeys() is undefined.  Use Counter(iterable) instead.')
+
+    def update(self, iterable=None, **kwds):
+        '''Like dict.update() but add counts instead of replacing them.
+
+        Source can be an iterable, a dictionary, or another Counter instance.
+
+        >>> c = Counter('which')
+        >>> c.update('witch')           # add elements from another iterable
+        >>> d = Counter('watch')
+        >>> c.update(d)                 # add elements from another counter
+        >>> c['h']                      # four 'h' in which, witch, and watch
+        4
+
+        '''
+        # The regular dict.update() operation makes no sense here because the
+        # replace behavior results in the some of original untouched counts
+        # being mixed-in with all of the other counts for a mismash that
+        # doesn't have a straight-forward interpretation in most counting
+        # contexts.  Instead, we implement straight-addition.  Both the inputs
+        # and outputs are allowed to contain zero and negative counts.
+
+        if iterable is not None:
+            if isinstance(iterable, Mapping):
+                if self:
+                    self_get = self.get
+                    for elem, count in iterable.iteritems():
+                        self[elem] = self_get(elem, 0) + count
+                else:
+                    super(Counter, self).update(iterable) # fast path when counter is empty
+            else:
+                self_get = self.get
+                for elem in iterable:
+                    self[elem] = self_get(elem, 0) + 1
+        if kwds:
+            self.update(kwds)
+
+    def subtract(self, iterable=None, **kwds):
+        '''Like dict.update() but subtracts counts instead of replacing them.
+        Counts can be reduced below zero.  Both the inputs and outputs are
+        allowed to contain zero and negative counts.
+
+        Source can be an iterable, a dictionary, or another Counter instance.
+
+        >>> c = Counter('which')
+        >>> c.subtract('witch')             # subtract elements from another iterable
+        >>> c.subtract(Counter('watch'))    # subtract elements from another counter
+        >>> c['h']                          # 2 in which, minus 1 in witch, minus 1 in watch
+        0
+        >>> c['w']                          # 1 in which, minus 1 in witch, minus 1 in watch
+        -1
+
+        '''
+        if iterable is not None:
+            self_get = self.get
+            if isinstance(iterable, Mapping):
+                for elem, count in iterable.items():
+                    self[elem] = self_get(elem, 0) - count
+            else:
+                for elem in iterable:
+                    self[elem] = self_get(elem, 0) - 1
+        if kwds:
+            self.subtract(kwds)
+
+    def copy(self):
+        'Return a shallow copy.'
+        return self.__class__(self)
+
+    def __reduce__(self):
+        return self.__class__, (dict(self),)
+
+    def __delitem__(self, elem):
+        'Like dict.__delitem__() but does not raise KeyError for missing values.'
+        if elem in self:
+            super(Counter, self).__delitem__(elem)
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % self.__class__.__name__
+        items = ', '.join(map('%r: %r'.__mod__, self.most_common()))
+        return '%s({%s})' % (self.__class__.__name__, items)
+
+    # Multiset-style mathematical operations discussed in:
+    #       Knuth TAOCP Volume II section 4.6.3 exercise 19
+    #       and at http://en.wikipedia.org/wiki/Multiset
+    #
+    # Outputs guaranteed to only include positive counts.
+    #
+    # To strip negative and zero counts, add-in an empty counter:
+    #       c += Counter()
+
+    def __add__(self, other):
+        '''Add counts from two counters.
+
+        >>> Counter('abbb') + Counter('bcc')
+        Counter({'b': 4, 'c': 2, 'a': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            newcount = count + other[elem]
+            if newcount > 0:
+                result[elem] = newcount
+        for elem, count in other.items():
+            if elem not in self and count > 0:
+                result[elem] = count
+        return result
+
+    def __sub__(self, other):
+        ''' Subtract count, but keep only results with positive counts.
+
+        >>> Counter('abbbc') - Counter('bccd')
+        Counter({'b': 2, 'a': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            newcount = count - other[elem]
+            if newcount > 0:
+                result[elem] = newcount
+        for elem, count in other.items():
+            if elem not in self and count < 0:
+                result[elem] = 0 - count
+        return result
+
+    def __or__(self, other):
+        '''Union is the maximum of value in either of the input counters.
+
+        >>> Counter('abbb') | Counter('bcc')
+        Counter({'b': 3, 'c': 2, 'a': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            other_count = other[elem]
+            newcount = other_count if count < other_count else count
+            if newcount > 0:
+                result[elem] = newcount
+        for elem, count in other.items():
+            if elem not in self and count > 0:
+                result[elem] = count
+        return result
+
+    def __and__(self, other):
+        ''' Intersection is the minimum of corresponding counts.
+
+        >>> Counter('abbb') & Counter('bcc')
+        Counter({'b': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            other_count = other[elem]
+            newcount = count if count < other_count else other_count
+            if newcount > 0:
+                result[elem] = newcount
+        return result
 
 
 if __name__ == '__main__':

--- a/src/heapq.py
+++ b/src/heapq.py
@@ -1,0 +1,442 @@
+# -*- coding: latin-1 -*-
+
+"""Heap queue algorithm (a.k.a. priority queue).
+
+Heaps are arrays for which a[k] <= a[2*k+1] and a[k] <= a[2*k+2] for
+all k, counting elements from 0.  For the sake of comparison,
+non-existing elements are considered to be infinite.  The interesting
+property of a heap is that a[0] is always its smallest element.
+
+Usage:
+
+heap = []            # creates an empty heap
+heappush(heap, item) # pushes a new item on the heap
+item = heappop(heap) # pops the smallest item from the heap
+item = heap[0]       # smallest item on the heap without popping it
+heapify(x)           # transforms list into a heap, in-place, in linear time
+item = heapreplace(heap, item) # pops and returns smallest item, and adds
+                               # new item; the heap size is unchanged
+
+Our API differs from textbook heap algorithms as follows:
+
+- We use 0-based indexing.  This makes the relationship between the
+  index for a node and the indexes for its children slightly less
+  obvious, but is more suitable since Python uses 0-based indexing.
+
+- Our heappop() method returns the smallest item, not the largest.
+
+These two make it possible to view the heap as a regular Python list
+without surprises: heap[0] is the smallest item, and heap.sort()
+maintains the heap invariant!
+"""
+
+# Original code by Kevin O'Connor, augmented by Tim Peters and Raymond Hettinger
+
+__about__ = """Heap queues
+
+[explanation by François Pinard]
+
+Heaps are arrays for which a[k] <= a[2*k+1] and a[k] <= a[2*k+2] for
+all k, counting elements from 0.  For the sake of comparison,
+non-existing elements are considered to be infinite.  The interesting
+property of a heap is that a[0] is always its smallest element.
+
+The strange invariant above is meant to be an efficient memory
+representation for a tournament.  The numbers below are `k', not a[k]:
+
+                                   0
+
+                  1                                 2
+
+          3               4                5               6
+
+      7       8       9       10      11      12      13      14
+
+    15 16   17 18   19 20   21 22   23 24   25 26   27 28   29 30
+
+
+In the tree above, each cell `k' is topping `2*k+1' and `2*k+2'.  In
+an usual binary tournament we see in sports, each cell is the winner
+over the two cells it tops, and we can trace the winner down the tree
+to see all opponents s/he had.  However, in many computer applications
+of such tournaments, we do not need to trace the history of a winner.
+To be more memory efficient, when a winner is promoted, we try to
+replace it by something else at a lower level, and the rule becomes
+that a cell and the two cells it tops contain three different items,
+but the top cell "wins" over the two topped cells.
+
+If this heap invariant is protected at all time, index 0 is clearly
+the overall winner.  The simplest algorithmic way to remove it and
+find the "next" winner is to move some loser (let's say cell 30 in the
+diagram above) into the 0 position, and then percolate this new 0 down
+the tree, exchanging values, until the invariant is re-established.
+This is clearly logarithmic on the total number of items in the tree.
+By iterating over all items, you get an O(n ln n) sort.
+
+A nice feature of this sort is that you can efficiently insert new
+items while the sort is going on, provided that the inserted items are
+not "better" than the last 0'th element you extracted.  This is
+especially useful in simulation contexts, where the tree holds all
+incoming events, and the "win" condition means the smallest scheduled
+time.  When an event schedule other events for execution, they are
+scheduled into the future, so they can easily go into the heap.  So, a
+heap is a good structure for implementing schedulers (this is what I
+used for my MIDI sequencer :-).
+
+Various structures for implementing schedulers have been extensively
+studied, and heaps are good for this, as they are reasonably speedy,
+the speed is almost constant, and the worst case is not much different
+than the average case.  However, there are other representations which
+are more efficient overall, yet the worst cases might be terrible.
+
+Heaps are also very useful in big disk sorts.  You most probably all
+know that a big sort implies producing "runs" (which are pre-sorted
+sequences, which size is usually related to the amount of CPU memory),
+followed by a merging passes for these runs, which merging is often
+very cleverly organised[1].  It is very important that the initial
+sort produces the longest runs possible.  Tournaments are a good way
+to that.  If, using all the memory available to hold a tournament, you
+replace and percolate items that happen to fit the current run, you'll
+produce runs which are twice the size of the memory for random input,
+and much better for input fuzzily ordered.
+
+Moreover, if you output the 0'th item on disk and get an input which
+may not fit in the current tournament (because the value "wins" over
+the last output value), it cannot fit in the heap, so the size of the
+heap decreases.  The freed memory could be cleverly reused immediately
+for progressively building a second heap, which grows at exactly the
+same rate the first heap is melting.  When the first heap completely
+vanishes, you switch heaps and start a new run.  Clever and quite
+effective!
+
+In a word, heaps are useful memory structures to know.  I use them in
+a few applications, and I think it is good to keep a `heap' module
+around. :-)
+
+--------------------
+[1] The disk balancing algorithms which are current, nowadays, are
+more annoying than clever, and this is a consequence of the seeking
+capabilities of the disks.  On devices which cannot seek, like big
+tape drives, the story was quite different, and one had to be very
+clever to ensure (far in advance) that each tape movement will be the
+most effective possible (that is, will best participate at
+"progressing" the merge).  Some tapes were even able to read
+backwards, and this was also used to avoid the rewinding time.
+Believe me, real good tape sorts were quite spectacular to watch!
+From all times, sorting has always been a Great Art! :-)
+"""
+
+__all__ = ['heappush', 'heappop', 'heapify', 'heapreplace', 'merge',
+           'nlargest', 'nsmallest', 'heappushpop']
+
+from itertools import islice, repeat, count, imap, izip, tee, chain
+from operator import itemgetter
+import bisect
+
+def cmp_lt(x, y):
+    # Use __lt__ if available; otherwise, try __le__.
+    # In Py3.x, only __lt__ will be called.
+    return (x < y) if hasattr(x, '__lt__') else (not y <= x)
+
+def heappush(heap, item):
+    """Push item onto heap, maintaining the heap invariant."""
+    heap.append(item)
+    _siftdown(heap, 0, len(heap)-1)
+
+def heappop(heap):
+    """Pop the smallest item off the heap, maintaining the heap invariant."""
+    lastelt = heap.pop()    # raises appropriate IndexError if heap is empty
+    if heap:
+        returnitem = heap[0]
+        heap[0] = lastelt
+        _siftup(heap, 0)
+    else:
+        returnitem = lastelt
+    return returnitem
+
+def heapreplace(heap, item):
+    """Pop and return the current smallest value, and add the new item.
+
+    This is more efficient than heappop() followed by heappush(), and can be
+    more appropriate when using a fixed-size heap.  Note that the value
+    returned may be larger than item!  That constrains reasonable uses of
+    this routine unless written as part of a conditional replacement:
+
+        if item > heap[0]:
+            item = heapreplace(heap, item)
+    """
+    returnitem = heap[0]    # raises appropriate IndexError if heap is empty
+    heap[0] = item
+    _siftup(heap, 0)
+    return returnitem
+
+def heappushpop(heap, item):
+    """Fast version of a heappush followed by a heappop."""
+    if heap and cmp_lt(heap[0], item):
+        item, heap[0] = heap[0], item
+        _siftup(heap, 0)
+    return item
+
+def heapify(x):
+    """Transform list into a heap, in-place, in O(len(x)) time."""
+    n = len(x)
+    # Transform bottom-up.  The largest index there's any point to looking at
+    # is the largest with a child index in-range, so must have 2*i + 1 < n,
+    # or i < (n-1)/2.  If n is even = 2*j, this is (2*j-1)/2 = j-1/2 so
+    # j-1 is the largest, which is n//2 - 1.  If n is odd = 2*j+1, this is
+    # (2*j+1-1)/2 = j so j-1 is the largest, and that's again n//2-1.
+    for i in reversed(xrange(n//2)):
+        _siftup(x, i)
+
+def nlargest(n, iterable):
+    """Find the n largest elements in a dataset.
+
+    Equivalent to:  sorted(iterable, reverse=True)[:n]
+    """
+    it = iter(iterable)
+    result = list(islice(it, n))
+    if not result:
+        return result
+    heapify(result)
+    _heappushpop = heappushpop
+    for elem in it:
+        _heappushpop(result, elem)
+    result.sort(reverse=True)
+    return result
+
+def nsmallest(n, iterable):
+    """Find the n smallest elements in a dataset.
+
+    Equivalent to:  sorted(iterable)[:n]
+    """
+    if hasattr(iterable, '__len__') and n * 10 <= len(iterable):
+        # For smaller values of n, the bisect method is faster than a minheap.
+        # It is also memory efficient, consuming only n elements of space.
+        it = iter(iterable)
+        result = sorted(islice(it, 0, n))
+        if not result:
+            return result
+        insort = bisect.insort
+        pop = result.pop
+        los = result[-1]    # los --> Largest of the nsmallest
+        for elem in it:
+            if cmp_lt(elem, los):
+                insort(result, elem)
+                pop()
+                los = result[-1]
+        return result
+    # An alternative approach manifests the whole iterable in memory but
+    # saves comparisons by heapifying all at once.  Also, saves time
+    # over bisect.insort() which has O(n) data movement time for every
+    # insertion.  Finding the n smallest of an m length iterable requires
+    #    O(m) + O(n log m) comparisons.
+    h = list(iterable)
+    heapify(h)
+    return map(heappop, repeat(h, min(n, len(h))))
+
+# 'heap' is a heap at all indices >= startpos, except possibly for pos.  pos
+# is the index of a leaf with a possibly out-of-order value.  Restore the
+# heap invariant.
+def _siftdown(heap, startpos, pos):
+    newitem = heap[pos]
+    # Follow the path to the root, moving parents down until finding a place
+    # newitem fits.
+    while pos > startpos:
+        parentpos = (pos - 1) >> 1
+        parent = heap[parentpos]
+        if cmp_lt(newitem, parent):
+            heap[pos] = parent
+            pos = parentpos
+            continue
+        break
+    heap[pos] = newitem
+
+# The child indices of heap index pos are already heaps, and we want to make
+# a heap at index pos too.  We do this by bubbling the smaller child of
+# pos up (and so on with that child's children, etc) until hitting a leaf,
+# then using _siftdown to move the oddball originally at index pos into place.
+#
+# We *could* break out of the loop as soon as we find a pos where newitem <=
+# both its children, but turns out that's not a good idea, and despite that
+# many books write the algorithm that way.  During a heap pop, the last array
+# element is sifted in, and that tends to be large, so that comparing it
+# against values starting from the root usually doesn't pay (= usually doesn't
+# get us out of the loop early).  See Knuth, Volume 3, where this is
+# explained and quantified in an exercise.
+#
+# Cutting the # of comparisons is important, since these routines have no
+# way to extract "the priority" from an array element, so that intelligence
+# is likely to be hiding in custom __cmp__ methods, or in array elements
+# storing (priority, record) tuples.  Comparisons are thus potentially
+# expensive.
+#
+# On random arrays of length 1000, making this change cut the number of
+# comparisons made by heapify() a little, and those made by exhaustive
+# heappop() a lot, in accord with theory.  Here are typical results from 3
+# runs (3 just to demonstrate how small the variance is):
+#
+# Compares needed by heapify     Compares needed by 1000 heappops
+# --------------------------     --------------------------------
+# 1837 cut to 1663               14996 cut to 8680
+# 1855 cut to 1659               14966 cut to 8678
+# 1847 cut to 1660               15024 cut to 8703
+#
+# Building the heap by using heappush() 1000 times instead required
+# 2198, 2148, and 2219 compares:  heapify() is more efficient, when
+# you can use it.
+#
+# The total compares needed by list.sort() on the same lists were 8627,
+# 8627, and 8632 (this should be compared to the sum of heapify() and
+# heappop() compares):  list.sort() is (unsurprisingly!) more efficient
+# for sorting.
+
+def _siftup(heap, pos):
+    endpos = len(heap)
+    startpos = pos
+    newitem = heap[pos]
+    # Bubble up the smaller child until hitting a leaf.
+    childpos = 2*pos + 1    # leftmost child position
+    while childpos < endpos:
+        # Set childpos to index of smaller child.
+        rightpos = childpos + 1
+        if rightpos < endpos and not cmp_lt(heap[childpos], heap[rightpos]):
+            childpos = rightpos
+        # Move the smaller child up.
+        heap[pos] = heap[childpos]
+        pos = childpos
+        childpos = 2*pos + 1
+    # The leaf at pos is empty now.  Put newitem there, and bubble it up
+    # to its final resting place (by sifting its parents down).
+    heap[pos] = newitem
+    _siftdown(heap, startpos, pos)
+
+# If available, use C implementation
+try:
+    from _heapq import *
+except ImportError:
+    pass
+
+def merge(*iterables):
+    '''Merge multiple sorted inputs into a single sorted output.
+
+    Similar to sorted(itertools.chain(*iterables)) but returns a generator,
+    does not pull the data into memory all at once, and assumes that each of
+    the input streams is already sorted (smallest to largest).
+
+    >>> list(merge([1,3,5,7], [0,2,4,8], [5,10,15,20], [], [25]))
+    [0, 1, 2, 3, 4, 5, 5, 7, 8, 10, 15, 20, 25]
+
+    '''
+    _heappop, _heapreplace, _StopIteration = heappop, heapreplace, StopIteration
+
+    h = []
+    h_append = h.append
+    for itnum, it in enumerate(map(iter, iterables)):
+        try:
+            next = it.next
+            h_append([next(), itnum, next])
+        except _StopIteration:
+            pass
+    heapify(h)
+
+    while 1:
+        try:
+            while 1:
+                v, itnum, next = s = h[0]   # raises IndexError when h is empty
+                yield v
+                s[0] = next()               # raises StopIteration when exhausted
+                _heapreplace(h, s)          # restore heap condition
+        except _StopIteration:
+            _heappop(h)                     # remove empty iterator
+        except IndexError:
+            return
+
+# Extend the implementations of nsmallest and nlargest to use a key= argument
+_nsmallest = nsmallest
+def nsmallest(n, iterable, key=None):
+    """Find the n smallest elements in a dataset.
+
+    Equivalent to:  sorted(iterable, key=key)[:n]
+    """
+    # Short-cut for n==1 is to use min() when len(iterable)>0
+    if n == 1:
+        it = iter(iterable)
+        head = list(islice(it, 1))
+        if not head:
+            return []
+        if key is None:
+            return [min(chain(head, it))]
+        return [min(chain(head, it), key=key)]
+
+    # When n>=size, it's faster to use sorted()
+    try:
+        size = len(iterable)
+    except (TypeError, AttributeError):
+        pass
+    else:
+        if n >= size:
+            return sorted(iterable, key=key)[:n]
+
+    # When key is none, use simpler decoration
+    if key is None:
+        it = izip(iterable, count())                        # decorate
+        result = _nsmallest(n, it)
+        return map(itemgetter(0), result)                   # undecorate
+
+    # General case, slowest method
+    in1, in2 = tee(iterable)
+    it = izip(imap(key, in1), count(), in2)                 # decorate
+    result = _nsmallest(n, it)
+    return map(itemgetter(2), result)                       # undecorate
+
+_nlargest = nlargest
+def nlargest(n, iterable, key=None):
+    """Find the n largest elements in a dataset.
+
+    Equivalent to:  sorted(iterable, key=key, reverse=True)[:n]
+    """
+
+    # Short-cut for n==1 is to use max() when len(iterable)>0
+    if n == 1:
+        it = iter(iterable)
+        head = list(islice(it, 1))
+        if not head:
+            return []
+        if key is None:
+            return [max(chain(head, it))]
+        return [max(chain(head, it), key=key)]
+
+    # When n>=size, it's faster to use sorted()
+    try:
+        size = len(iterable)
+    except (TypeError, AttributeError):
+        pass
+    else:
+        if n >= size:
+            return sorted(iterable, key=key, reverse=True)[:n]
+
+    # When key is none, use simpler decoration
+    if key is None:
+        it = izip(iterable, count(0,-1))                    # decorate
+        result = _nlargest(n, it)
+        return map(itemgetter(0), result)                   # undecorate
+
+    # General case, slowest method
+    in1, in2 = tee(iterable)
+    it = izip(imap(key, in1), count(0,-1), in2)             # decorate
+    result = _nlargest(n, it)
+    return map(itemgetter(2), result)                       # undecorate
+
+if __name__ == "__main__":
+    # Simple sanity test
+    heap = []
+    data = [1, 3, 5, 7, 9, 2, 4, 6, 8, 0]
+    for item in data:
+        heappush(heap, item)
+    sort = []
+    while heap:
+        sort.append(heappop(heap))
+    print sort
+
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
The Config panel of the plugin is very messy. I tried to rework it.

- using complete words, phrases to describe all settings instead of abbreviations for all settings (FR/EN)
- Gather all scrapable data choices into a single ListCheckButton instead of the all the CheckButtons
- Gather everything linked to Log/Debug in a third tab
- Replaced the three-state CheckButton for Scraping Web Link into a normal CheckButton (scrape weblink or not) + a new option to store shortened link (compatible with the previous setting storage)
- Replaced the "Pause Scrape" three-state CheckButton (checked=allow user to choose when non univoque choice arise, unchecked=not allowing to choose and always choose 1st item or skipping to next and indeterminate=allow user to choose when non univoque choice arise BUT with a timer...) by a simplified choice "Decision when an ambiguity in the choice of series or book arises" with two options "Ignore and skip to next" or "User choose between choices". To use or not a timer for choice pop-up is now hidden in the TIMEOUT given to this pop-up before it closes (if using "0" = no timer) (compatible with the previous setting storage)
- Changed the max size of log files to show MegaBytes instead of Bytes (stored parameters still in Bytes to keep compatibility)
- Also simplified some regex strings where a lot of characters where protected for no reason (\- \/ \: \")
- Fixed the SERIE_QSERIE_PATTERN that should have returned the name of a serie from an album page (Quickscrape/Rescrape only). Also, the condition to use it was if the serie title was blank ??? I removed this strange condition. A Quickscrape/Rescrape will always reset the Serie Title from the album page info now.